### PR TITLE
Remove themekit dependency from frameworks

### DIFF
--- a/Frameworks/NavigationKit.xcodeproj/project.pbxproj
+++ b/Frameworks/NavigationKit.xcodeproj/project.pbxproj
@@ -30,8 +30,6 @@
 		D62651382B3F5D410089A84B /* NavigatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62651372B3F5D410089A84B /* NavigatorDelegate.swift */; };
 		D626513A2B3F5DD70089A84B /* NavHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62651392B3F5DD70089A84B /* NavHost.swift */; };
 		D626513C2B3F5E020089A84B /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D626513B2B3F5E020089A84B /* Navigator.swift */; };
-		D6C89A242B5734FA00B9EEC9 /* NavBarColorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C89A232B5734FA00B9EEC9 /* NavBarColorConfiguration.swift */; };
-		D6CA77422B4171D700C98AF3 /* ThemeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6CA77412B4171D700C98AF3 /* ThemeKit.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,7 +57,6 @@
 		D62651372B3F5D410089A84B /* NavigatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorDelegate.swift; sourceTree = "<group>"; };
 		D62651392B3F5DD70089A84B /* NavHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavHost.swift; sourceTree = "<group>"; };
 		D626513B2B3F5E020089A84B /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
-		D6C89A232B5734FA00B9EEC9 /* NavBarColorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavBarColorConfiguration.swift; sourceTree = "<group>"; };
 		D6CA77412B4171D700C98AF3 /* ThemeKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ThemeKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -68,7 +65,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D6CA77422B4171D700C98AF3 /* ThemeKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -158,7 +154,6 @@
 			children = (
 				D626512A2B3F48EC0089A84B /* NavBarConfigurationState.swift */,
 				D626510C2B3F135D0089A84B /* NavBarTitleConfiguration.swift */,
-				D6C89A232B5734FA00B9EEC9 /* NavBarColorConfiguration.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -267,7 +262,6 @@
 				D626511A2B3F470F0089A84B /* CustomNavBarPrefKey.swift in Sources */,
 				D626510F2B3F13DC0089A84B /* _EquatableView.swift in Sources */,
 				D62651202B3F47560089A84B /* NavBarBackgroundPrefKey.swift in Sources */,
-				D6C89A242B5734FA00B9EEC9 /* NavBarColorConfiguration.swift in Sources */,
 				D62651182B3F465C0089A84B /* NavBarScrollingPrefKey.swift in Sources */,
 				D626512B2B3F48EC0089A84B /* NavBarConfigurationState.swift in Sources */,
 				D62651382B3F5D410089A84B /* NavigatorDelegate.swift in Sources */,

--- a/Frameworks/NavigationKit.xcodeproj/project.pbxproj
+++ b/Frameworks/NavigationKit.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		D62651382B3F5D410089A84B /* NavigatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62651372B3F5D410089A84B /* NavigatorDelegate.swift */; };
 		D626513A2B3F5DD70089A84B /* NavHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62651392B3F5DD70089A84B /* NavHost.swift */; };
 		D626513C2B3F5E020089A84B /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D626513B2B3F5E020089A84B /* Navigator.swift */; };
+		D6C89A242B5734FA00B9EEC9 /* NavBarColorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C89A232B5734FA00B9EEC9 /* NavBarColorConfiguration.swift */; };
 		D6CA77422B4171D700C98AF3 /* ThemeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6CA77412B4171D700C98AF3 /* ThemeKit.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 /* End PBXBuildFile section */
 
@@ -58,6 +59,7 @@
 		D62651372B3F5D410089A84B /* NavigatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorDelegate.swift; sourceTree = "<group>"; };
 		D62651392B3F5DD70089A84B /* NavHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavHost.swift; sourceTree = "<group>"; };
 		D626513B2B3F5E020089A84B /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		D6C89A232B5734FA00B9EEC9 /* NavBarColorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavBarColorConfiguration.swift; sourceTree = "<group>"; };
 		D6CA77412B4171D700C98AF3 /* ThemeKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ThemeKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -156,6 +158,7 @@
 			children = (
 				D626512A2B3F48EC0089A84B /* NavBarConfigurationState.swift */,
 				D626510C2B3F135D0089A84B /* NavBarTitleConfiguration.swift */,
+				D6C89A232B5734FA00B9EEC9 /* NavBarColorConfiguration.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 				D626511A2B3F470F0089A84B /* CustomNavBarPrefKey.swift in Sources */,
 				D626510F2B3F13DC0089A84B /* _EquatableView.swift in Sources */,
 				D62651202B3F47560089A84B /* NavBarBackgroundPrefKey.swift in Sources */,
+				D6C89A242B5734FA00B9EEC9 /* NavBarColorConfiguration.swift in Sources */,
 				D62651182B3F465C0089A84B /* NavBarScrollingPrefKey.swift in Sources */,
 				D626512B2B3F48EC0089A84B /* NavBarConfigurationState.swift in Sources */,
 				D62651382B3F5D410089A84B /* NavigatorDelegate.swift in Sources */,

--- a/Frameworks/NavigationKit/Model/NavBarColorConfiguration.swift
+++ b/Frameworks/NavigationKit/Model/NavBarColorConfiguration.swift
@@ -1,0 +1,8 @@
+//
+//  NavBarColorConfiguration.swift
+//  NavigationKit
+//
+//  Created by Tomasz Kubiak on 16/01/2024.
+//
+
+import Foundation

--- a/Frameworks/NavigationKit/Model/NavBarColorConfiguration.swift
+++ b/Frameworks/NavigationKit/Model/NavBarColorConfiguration.swift
@@ -1,8 +1,0 @@
-//
-//  NavBarColorConfiguration.swift
-//  NavigationKit
-//
-//  Created by Tomasz Kubiak on 16/01/2024.
-//
-
-import Foundation

--- a/Frameworks/NavigationKit/Model/NavBarTitleConfiguration.swift
+++ b/Frameworks/NavigationKit/Model/NavBarTitleConfiguration.swift
@@ -6,13 +6,12 @@
 //
 
 import SwiftUI
-import ThemeKit
 
 public struct NavBarTitleConfiguration: Equatable {
     public var title: AttributedString
     public var alignment: Alignment
     
-    public init(title: String, textColor: Color = .theme.black, font: Font = .title, alignment: Alignment = .leading) {
+    public init(title: String, textColor: Color = .black, font: Font = .title, alignment: Alignment = .leading) {
         self.title = {
             var attributedString = AttributedString(title)
             attributedString.font = font

--- a/Frameworks/NavigationKit/View/CustomNavigationBarView.swift
+++ b/Frameworks/NavigationKit/View/CustomNavigationBarView.swift
@@ -6,13 +6,13 @@
 //
 
 import SwiftUI
-import ThemeKit
 
 struct CustomNavigationBarView: View {
     @State private var barItemsWidth: CGFloat = 0
     let config: NavBarTitleConfiguration
     let shouldShowBackButton: Bool
     let background: _EquatableView
+    let backButtonColor: Color = .black
     let leadingElements: _EquatableView
     let trailingElements: _EquatableView
     let shouldElevate: Bool
@@ -102,7 +102,7 @@ struct CustomNavigationBarView: View {
             Text("Back")
         }
         .font(.system(size: 16))
-        .foregroundColor(Color.theme.primary)
+        .foregroundColor(backButtonColor)
         .onTapGesture {
             onBackTapped()
         }
@@ -153,27 +153,25 @@ private extension CustomNavigationBarView {
             }
             return NavBarTitleConfiguration(title: title)
         }()
-//        NavBarTitleConfiguration(title: "PunchPad", font: .system(size: 32))
         
         var navBarBackground: some View {
             RoundedRectangle(cornerRadius: 24)
                 .foregroundColor(.white)
                 .ignoresSafeArea(edges: .top)
-                .background(Color.theme.background)
+                .background(Color.white)
                 .shadow(color: .black.opacity(0.2), radius: 12, x: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/, y: 4)
         }
         var leadingElements: some View {
-            Logo.logo()
-                .resizable()
+            Circle()
                 .frame(width: 26, height: 26)
         }
         var trailingElements: some View {
             Image(systemName:"gearshape.fill")
-                .foregroundColor(.theme.primary)
+                .foregroundColor(.green)
         }
         
         var background: some View {
-            Color.theme.background
+            Color.gray
                 .ignoresSafeArea()
         }
         var body: some View {
@@ -194,26 +192,27 @@ private extension CustomNavigationBarView {
 
 #Preview("History configuration") {
     struct Preview: View {
-        let navBarTitleConfiguration = NavBarTitleConfiguration(title: "History", font: .system(size: 32,weight: .semibold))
+        let navBarTitleConfiguration = NavBarTitleConfiguration(title: "History", 
+                                                                font: .system(size: 32,weight: .semibold))
         var navBarBackground: some View {
             RoundedRectangle(cornerRadius: 24)
                 .foregroundColor(.white)
                 .ignoresSafeArea(edges: .top)
-                .background(Color.theme.background)
+                .background(Color.gray)
                 .shadow(color: .black.opacity(0.2), radius: 12, x: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/, y: 4)
         }
         var leadingElements: some View {
             Image(systemName: "plus")
                 .font(.title)
-                .foregroundColor(.theme.primary)
+                .foregroundColor(.green)
         }
         var trailingElements: some View {
             Image(systemName:"gearshape.fill")
-                .foregroundColor(.theme.primary)
+                .foregroundColor(.green)
         }
         
         var background: some View {
-            Color.theme.background
+            Color.gray
                 .ignoresSafeArea()
         }
         var body: some View {
@@ -239,15 +238,15 @@ private extension CustomNavigationBarView {
             RoundedRectangle(cornerRadius: 24)
                 .foregroundColor(.white)
                 .ignoresSafeArea(edges: .top)
-                .background(Color.theme.background)
+                .background(Color.white)
                 .shadow(color: .black.opacity(0.2), radius: 12, x: 0, y: 4)
         }
         var trailingElements: some View {
             Image(systemName:"gearshape.fill")
-                .foregroundColor(.theme.primary)
+                .foregroundColor(.green)
         }
         var background: some View {
-            Color.theme.background
+            Color.gray
                 .ignoresSafeArea()
         }
         var body: some View {
@@ -273,11 +272,11 @@ private extension CustomNavigationBarView {
             RoundedRectangle(cornerRadius: 24)
                 .foregroundColor(.white)
                 .ignoresSafeArea(edges: .top)
-                .background(Color.theme.background)
+                .background(Color.gray)
                 .shadow(color: .black.opacity(0.2), radius: 12, x: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/, y: 4)
         }
         var background: some View {
-            Color.theme.background
+            Color.gray
                 .ignoresSafeArea()
         }
         var body: some View {

--- a/Frameworks/TabViewKit.xcodeproj/project.pbxproj
+++ b/Frameworks/TabViewKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D622866D2B4094D100B41004 /* TabBarIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D622866C2B4094D100B41004 /* TabBarIdentifier.swift */; };
+		D6C89A222B572A6200B9EEC9 /* TabBarColorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C89A212B572A6200B9EEC9 /* TabBarColorConfiguration.swift */; };
 		D6D9BAC62B407A8F002D4C19 /* TabViewKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D6D9BAC52B407A8F002D4C19 /* TabViewKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D6D9BAD52B407C33002D4C19 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D9BAD22B407C32002D4C19 /* TabBarItem.swift */; };
 		D6D9BAD62B407C33002D4C19 /* CustomTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D9BAD32B407C33002D4C19 /* CustomTabBarView.swift */; };
@@ -20,6 +21,7 @@
 
 /* Begin PBXFileReference section */
 		D622866C2B4094D100B41004 /* TabBarIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarIdentifier.swift; sourceTree = "<group>"; };
+		D6C89A212B572A6200B9EEC9 /* TabBarColorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarColorConfiguration.swift; sourceTree = "<group>"; };
 		D6D9BAC22B407A8F002D4C19 /* TabViewKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TabViewKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6D9BAC52B407A8F002D4C19 /* TabViewKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TabViewKit.h; sourceTree = "<group>"; };
 		D6D9BAD22B407C32002D4C19 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 			children = (
 				D6D9BAD22B407C32002D4C19 /* TabBarItem.swift */,
 				D622866C2B4094D100B41004 /* TabBarIdentifier.swift */,
+				D6C89A212B572A6200B9EEC9 /* TabBarColorConfiguration.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -206,6 +209,7 @@
 				D622866D2B4094D100B41004 /* TabBarIdentifier.swift in Sources */,
 				D6D9BAD72B407C33002D4C19 /* CustomTabView.swift in Sources */,
 				D6D9BAD62B407C33002D4C19 /* CustomTabBarView.swift in Sources */,
+				D6C89A222B572A6200B9EEC9 /* TabBarColorConfiguration.swift in Sources */,
 				D6D9BAD92B407CFF002D4C19 /* TabBarItemsPrefKey.swift in Sources */,
 				D6D9BADD2B407D50002D4C19 /* View+Extension.swift in Sources */,
 				D6D9BADB2B407D19002D4C19 /* TabBarItemViewModifier.swift in Sources */,

--- a/Frameworks/TabViewKit.xcodeproj/project.pbxproj
+++ b/Frameworks/TabViewKit.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		D6D9BAD92B407CFF002D4C19 /* TabBarItemsPrefKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D9BAD82B407CFE002D4C19 /* TabBarItemsPrefKey.swift */; };
 		D6D9BADB2B407D19002D4C19 /* TabBarItemViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D9BADA2B407D19002D4C19 /* TabBarItemViewModifier.swift */; };
 		D6D9BADD2B407D50002D4C19 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D9BADC2B407D50002D4C19 /* View+Extension.swift */; };
-		D6D9BAF82B408388002D4C19 /* ThemeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6D9BAF72B408388002D4C19 /* ThemeKit.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,7 +37,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D6D9BAF82B408388002D4C19 /* ThemeKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Frameworks/TabViewKit/Model/TabBarColorConfiguration.swift
+++ b/Frameworks/TabViewKit/Model/TabBarColorConfiguration.swift
@@ -1,0 +1,40 @@
+//
+//  TabBarColorConfiguration.swift
+//  TabViewKit
+//
+//  Created by Tomasz Kubiak on 16/01/2024.
+//
+
+import SwiftUI
+
+/// Configuration model for custom tab bar - provides color properties for the custom tab bar view.
+public struct TabBarColorConfiguration {
+    let inactiveColor: Color
+    let activeColor: Color
+    let shadowColor: Color
+    let backgroundColor: Color
+    
+    /// Create an instance of custom tab bar color configuration
+    /// - Parameters:
+    ///   - activeColor: color of the active tab bar item and its underline
+    ///   - inactiveColor: color of the inactive tab bar items and underline of all of the items
+    ///   - shadowColor: color of the shadow of the whole bar
+    ///   - backgroundColor: background color of the whole bar
+    public init(activeColor: Color,
+                inactiveColor: Color,
+                shadowColor: Color,
+                backgroundColor: Color) {
+        self.activeColor = activeColor
+        self.inactiveColor = inactiveColor
+        self.shadowColor = shadowColor
+        self.backgroundColor = backgroundColor
+    }
+    
+    /// Private initializer with some colors used for previews inside of the module
+    init() {
+        self.activeColor = Color.green
+        self.inactiveColor = Color.gray
+        self.shadowColor = Color.black.opacity(0.3)
+        self.backgroundColor = Color.white
+    }
+}

--- a/Frameworks/TabViewKit/Views/CustomTabBarView.swift
+++ b/Frameworks/TabViewKit/Views/CustomTabBarView.swift
@@ -6,18 +6,19 @@
 //
 
 import SwiftUI
-import ThemeKit
 
 public struct CustomTabBarView: View {
     @Binding var selection: TabBarItem
     @State private var localSelection: TabBarItem
     @Namespace private var namespance
     let tabs: [TabBarItem]
+    let configuration: TabBarColorConfiguration
     
-    public init(selection: Binding<TabBarItem>, tabs: [TabBarItem]) {
+    public init(selection: Binding<TabBarItem>, tabs: [TabBarItem], colorConfiguration: TabBarColorConfiguration) {
         self._selection = selection
         self._localSelection = State(initialValue: selection.wrappedValue)
         self.tabs = tabs
+        self.configuration = colorConfiguration
     }
     
     public var body: some View {
@@ -35,18 +36,18 @@ public struct CustomTabBarView: View {
             Rectangle()
                 .padding(.horizontal)
                 .offset(CGSize(width: 0, height: 12))
-                .foregroundColor(Color.theme.secondaryLabel)
+                .foregroundColor(configuration.inactiveColor)
                 .frame(maxWidth: .infinity)
                 .frame(height: 2)
         )
         .background(
-            Color.white
+            configuration.backgroundColor
                 .frame(height: 120)
                 .cornerRadius(24)
                 .ignoresSafeArea(edges: .bottom)
         )
         .compositingGroup()
-        .shadow(color: .theme.black.opacity(0.3), radius: 6, y: 4)
+        .shadow(color: configuration.shadowColor, radius: 6, y: 4)
         .onChange(of: selection, perform: { value in
             withAnimation(.easeInOut) {
                 localSelection = selection
@@ -62,14 +63,14 @@ public struct CustomTabBarView: View {
                 .font(.system(size: 20))
                 .accessibilityIdentifier(tab.identifier)
         }
-        .foregroundColor(localSelection == tab ? Color.theme.primary : Color.theme.secondaryLabel)
+        .foregroundColor(localSelection == tab ? configuration.activeColor : configuration.inactiveColor)
         .frame(maxWidth: .infinity)
         .background(
             ZStack{
                 if localSelection == tab {
                     Rectangle()
                         .offset(CGSize(width: 0, height: 18))
-                        .foregroundColor(Color.theme.primary)
+                        .foregroundColor(configuration.activeColor)
                         .frame(maxWidth: .infinity)
                         .frame(height: 3)
                         .matchedGeometryEffect(id: "tab_marker", in: namespance)
@@ -89,11 +90,12 @@ public struct CustomTabBarView: View {
         @State private var tabSection: TabBarItem = .home
         var body: some View {
             ZStack {
-                Color.theme.background.ignoresSafeArea()
+                Color.green.ignoresSafeArea()
                 VStack{
                     Spacer()
                     CustomTabBarView(selection: $tabSection,
-                                     tabs: [.home, .history, .statistics]
+                                     tabs: [.home, .history, .statistics],
+                                     colorConfiguration: TabBarColorConfiguration()
                     )
                 }
             }

--- a/Frameworks/TabViewKit/Views/CustomTabView.swift
+++ b/Frameworks/TabViewKit/Views/CustomTabView.swift
@@ -9,11 +9,15 @@ import SwiftUI
 
 public struct CustomTabView<Content: View>: View  {
     let content: Content
+    let tabBarColorConfig: TabBarColorConfiguration
     @Binding var selection: TabBarItem
     @State private var tabs: [TabBarItem] = []
     
-    public init(selection: Binding<TabBarItem>, @ViewBuilder content: () -> Content) {
+    public init(selection: Binding<TabBarItem>, 
+                tabBarColorConfiguration: TabBarColorConfiguration,
+                @ViewBuilder content: () -> Content) {
         self._selection = selection
+        self.tabBarColorConfig = tabBarColorConfiguration
         self.content = content()
     }
     
@@ -21,7 +25,8 @@ public struct CustomTabView<Content: View>: View  {
         ZStack(alignment: .bottom) {
             content
             CustomTabBarView(selection: $selection,
-                             tabs: tabs)
+                             tabs: tabs,
+            colorConfiguration: tabBarColorConfig)
         }
         .onPreferenceChange(TabBarItemsPrefKey.self) { value in
             self.tabs = value
@@ -30,7 +35,7 @@ public struct CustomTabView<Content: View>: View  {
 }
 
 #Preview {
-    CustomTabView(selection: .constant(.home)) {
+    CustomTabView(selection: .constant(.home), tabBarColorConfiguration: TabBarColorConfiguration()) {
         Color.red
     }
 }

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		D621C0CC2B3B8BE40065DF8C /* TimerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D621C0CB2B3B8BE40065DF8C /* TimerIndicator.swift */; };
 		D629CEF92B3613660036579D /* TimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D629CEF82B3613660036579D /* TimerService.swift */; };
 		D629CEFB2B363B500036579D /* TimerServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D629CEFA2B363B500036579D /* TimerServiceTests.swift */; };
-		D630A53C2B47056C0098CA86 /* ThemeKit.framework in Resources */ = {isa = PBXBuildFile; fileRef = D630A53A2B4704EA0098CA86 /* ThemeKit.framework */; };
 		D630A53F2B473A320098CA86 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D630A53E2B473A320098CA86 /* LaunchScreen.storyboard */; };
 		D63753AE2B45DA2000386482 /* TextFieldStyle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63753AD2B45DA2000386482 /* TextFieldStyle+Extension.swift */; };
 		D63753B02B45DA5000386482 /* GreenBorderTextFieldStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63753AF2B45DA5000386482 /* GreenBorderTextFieldStyle.swift */; };
@@ -614,7 +613,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D630A53C2B47056C0098CA86 /* ThemeKit.framework in Resources */,
 				D630A53F2B473A320098CA86 /* LaunchScreen.storyboard in Resources */,
 				D6C4589B29D229230069D89B /* Preview Assets.xcassets in Resources */,
 				D6C4589829D229230069D89B /* Assets.xcassets in Resources */,

--- a/PunchPad/View/MainView.swift
+++ b/PunchPad/View/MainView.swift
@@ -29,6 +29,11 @@ struct MainView: View {
         return result
     }()
     
+    let tabBarColorConfiguration = TabBarColorConfiguration(activeColor: .theme.primary,
+                                                            inactiveColor: .theme.secondaryLabel,
+                                                            shadowColor: .theme.black.opacity(0.3),
+                                                            backgroundColor: .theme.white)
+    
     init(navigator: Navigator<Route>, tabSelection: Binding<TabBarItem>, container: Container) {
         self.navigator = navigator
         
@@ -52,7 +57,8 @@ struct MainView: View {
     }
     
     var body: some View {
-        CustomTabView(selection: $tabSelection) {
+        CustomTabView(selection: $tabSelection,
+                      tabBarColorConfiguration: tabBarColorConfiguration) {
             HomeView(viewModel: homeViewModel)
                 .tabBarItem(tab: .home, selection: $tabSelection)
             


### PR DESCRIPTION
In current state ThemeKit is used in both NavigationKit and CustomTabBarKit, as well as in main app. This results in situation when the main app target has to bundle theme kit with resources so that the frameworks can find themeKit as resource. 
This fails a check in app store connect and results in invalid directory error: "The bundle Payload/PunchPad.app/ThemeKit.framework is not contained in a correctly named directory. It should be under Frameworks."

This PR resolves above issue by removing dependency on ThemeKit from both frameworks and removing ThemeKit from bundled resources in main app target. 

Changes to NavigationKit: 
- remove theme kit reference from previews in CustomNavigationBarView
- Replace back button color with black 
Changes to CustomTabBarKit:
- Add TabBarColorConfiguration 
- Remove references to theme kit color from CustomTabBarView
- Add color configuration to inits of CustomTabBarView and CustomTabView
Changes to main app:
- implement tab bar color configuration in main view use it to configure customTabView in body