### PR TITLE
31 wrong time update on leaving background

### DIFF
--- a/PunchPad-Timer-Foreground-Background.xctestplan
+++ b/PunchPad-Timer-Foreground-Background.xctestplan
@@ -1,0 +1,53 @@
+{
+  "configurations" : [
+    {
+      "id" : "5CF637A5-79C5-4B9A-8115-E418BC661B79",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "ChartPeriodServiceTests",
+        "ClockInTests",
+        "EditSheetViewModelTests",
+        "HistoryViewModelTests",
+        "HomeViewModelModelTests\/test_displayedValue_whenFirstTimerFinished_whenSecondTimerStarts()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_whenSecondTimerWasStarted()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_whenTimeInBackgroundExceedsFirstTimeLimit()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_whenTimeInBackgroundExceedsSumOfTimeLimits()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_when_timerServiceWasNotStarted_noOvertime()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_when_timerServiceWasStarted_noOvertime()",
+        "HomeViewModelModelTests\/test_resumeTimerService_whenPaused_noOvertime()",
+        "HomeViewModelModelTests\/test_resumeTimerService_whenPaused_withOvertime()",
+        "HomeViewModelModelTests\/test_secondTimerFinished_stopsServiceAndSavesEntry()",
+        "HomeViewModelModelTests\/test_startSecondTimer_whenFirstIsFinished_firstRun()",
+        "HomeViewModelModelTests\/test_startSecondTimer_whenFirstIsFinished_secondRun()",
+        "HomeViewModelModelTests\/test_startTimerService_when_noOvertime_firstRun()",
+        "HomeViewModelModelTests\/test_startTimerService_when_noOvertime_secondRun()",
+        "HomeViewModelModelTests\/test_stopTimerService_stopsSecondTimerAndSavesEntry()",
+        "HomeViewModelModelTests\/test_stopTimerService_stopsServiceAndSavesEntry_noOvertime()",
+        "HomeViewModelModelTests\/test_timerFinished_stopsServiceAndSavesEntry_noOvertime()",
+        "HomeViewModelModelTests\/test_timerPropertiesUpdate_whenSecondTimerIsRunning()",
+        "HomeViewModelModelTests\/test_timerProperties_notUpdating_whenPaused_noOvertime()",
+        "HomeViewModelModelTests\/test_timerProperties_notUpdating_whenPaused_withOvertime()",
+        "HomeViewModelModelTests\/test_timerProperties_updateWhenRunning_noOvertime()",
+        "PayManagerTests",
+        "StatisticsViewModelTests",
+        "TimerServiceTests"
+      ],
+      "target" : {
+        "containerPath" : "container:PunchPad.xcodeproj",
+        "identifier" : "D6C4589F29D229230069D89B",
+        "name" : "PunchPadTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -42,8 +42,6 @@
 		D65FD53D29D8B259006CC34F /* PersistanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65FD53C29D8B259006CC34F /* PersistanceController.swift */; };
 		D66451062B56FF47003C537B /* ThemeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D630A53A2B4704EA0098CA86 /* ThemeKit.framework */; };
 		D66451072B56FF47003C537B /* ThemeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D630A53A2B4704EA0098CA86 /* ThemeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D66451092B56FF88003C537B /* PunchPadUITests.xctest in Resources */ = {isa = PBXBuildFile; fileRef = D6C458AA29D229230069D89B /* PunchPadUITests.xctest */; };
-		D664510A2B56FF8A003C537B /* PunchPadTests.xctest in Resources */ = {isa = PBXBuildFile; fileRef = D6C458A029D229230069D89B /* PunchPadTests.xctest */; };
 		D666ADCC2AC05A0500B74663 /* CaseIterable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D666ADCB2AC05A0500B74663 /* CaseIterable+Extension.swift */; };
 		D66750EA29D713C900757F17 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66750E929D713C900757F17 /* HistoryView.swift */; };
 		D66750EC29D71C8300757F17 /* HistoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66750EB29D71C8300757F17 /* HistoryRow.swift */; };
@@ -623,7 +621,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D664510A2B56FF8A003C537B /* PunchPadTests.xctest in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -631,7 +628,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D66451092B56FF88003C537B /* PunchPadUITests.xctest in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PunchPad.xcodeproj/xcshareddata/xcschemes/PunchPad.xcscheme
+++ b/PunchPad.xcodeproj/xcshareddata/xcschemes/PunchPad.xcscheme
@@ -29,7 +29,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:PunchPad-Timer-Foreground-Background.xctestplan">
+            reference = "container:PunchPad-Timer-Foreground-Background.xctestplan"
+            default = "YES">
          </TestPlanReference>
          <TestPlanReference
             reference = "container:PunchPadTests.xctestplan">

--- a/PunchPad.xcodeproj/xcshareddata/xcschemes/PunchPad.xcscheme
+++ b/PunchPad.xcodeproj/xcshareddata/xcschemes/PunchPad.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D6C4588F29D229210069D89B"
+               BuildableName = "PunchPad.app"
+               BlueprintName = "PunchPad"
+               ReferencedContainer = "container:PunchPad.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:PunchPad-Timer-Foreground-Background.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:PunchPadTests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D6C4589F29D229230069D89B"
+               BuildableName = "PunchPadTests.xctest"
+               BlueprintName = "PunchPadTests"
+               ReferencedContainer = "container:PunchPad.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D6C458A929D229230069D89B"
+               BuildableName = "PunchPadUITests.xctest"
+               BlueprintName = "PunchPadUITests"
+               ReferencedContainer = "container:PunchPad.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D6C4588F29D229210069D89B"
+            BuildableName = "PunchPad.app"
+            BlueprintName = "PunchPad"
+            ReferencedContainer = "container:PunchPad.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D6C4588F29D229210069D89B"
+            BuildableName = "PunchPad.app"
+            BlueprintName = "PunchPad"
+            ReferencedContainer = "container:PunchPad.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PunchPad.xcworkspace/contents.xcworkspacedata
+++ b/PunchPad.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,12 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:PunchPadTests.xctestplan">
+   </FileRef>
+   <FileRef
+      location = "group:PunchPad-Timer-Foreground-Background.xctestplan">
+   </FileRef>
+   <FileRef
       location = "container:PunchPad.xcodeproj">
    </FileRef>
    <FileRef

--- a/PunchPad/Model/TimerService.swift
+++ b/PunchPad/Model/TimerService.swift
@@ -74,9 +74,12 @@ class TimerService: ObservableObject {
         })
     }
     
+    /// Update the timer counter if it is running by a secified value
+    /// - Parameter addValue: value to add to the counter, default is 1
+    /// If the value added is larger than remaining time, it will be reduced to the remaining time left on timer. When reaching the timer limit, service state will be changed to `.finished`
     private func updateTimer(byAdding addValue: TimeInterval = 1) {
         guard self.serviceState == .running else { return }
-        counter += addValue
+        counter += addValue < remainingTime ? addValue : remainingTime
         withAnimation(.easeInOut) {
             updateProgressCounter()
         }

--- a/PunchPad/ViewModel/HomeViewModel.swift
+++ b/PunchPad/ViewModel/HomeViewModel.swift
@@ -201,7 +201,7 @@ extension HomeViewModel {
                 overtimeTimerService.send(event: .resumeWith(overtimeTimerService.remainingTime))
             }
         } else {
-            workTimerService.send(event: .resumeWith(workTimerService.remainingTime))
+            workTimerService.send(event: .resumeWith(timePassedInBackground))
         }
     }
     

--- a/PunchPad/ViewModel/HomeViewModel.swift
+++ b/PunchPad/ViewModel/HomeViewModel.swift
@@ -223,7 +223,12 @@ extension HomeViewModel {
     func resumeFromBackground(_ appDidEnterBackgroundDate: Date) {
         let timePassedInBackground = DateInterval(start: appDidEnterBackgroundDate, end: Date()).duration
         guard let overtimeTimerService else {
-            workTimerService.send(event: .resumeWith(timePassedInBackground))
+            if timePassedInBackground < workTimerService.remainingTime {
+                workTimerService.send(event: .resumeWith(timePassedInBackground))
+            } else {
+                self.finishDate = appDidEnterBackgroundDate.addingTimeInterval(workTimerService.remainingTime)
+                workTimerService.send(event: .resumeWith(timePassedInBackground))
+            }
             return
         }
         if workTimerService.remainingTime < timePassedInBackground {

--- a/PunchPad/ViewModel/HomeViewModel.swift
+++ b/PunchPad/ViewModel/HomeViewModel.swift
@@ -219,19 +219,19 @@ extension HomeViewModel {
         }
     }
     
-    
-    @objc private func appDidEnterBackground() {
-        if workTimerService.serviceState == .running {
-            appDidEnterBackgroundDate = Date()
-            let timeToTimerFinish: TimeInterval? = {
-                if workTimerService.serviceState == .running {
-                    return workTimerService.remainingTime
-                }
-                return nil
-            }()
-            guard let timeToTimerFinish else { return }
+    private func appDidEnterBackground() {
+        // update background entrance date
+        appDidEnterBackgroundDate = Date()
+        // schedule notifications
+        if let overtimeTimerService,
+           overtimeTimerService.serviceState == .running {
+            let timerToTimerFinish: TimeInterval = overtimeTimerService.remainingTime
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timerToTimerFinish, repeats: false)
+            checkForPermissionAndDispatch(withTrigger: trigger) // schedule notification for end of overtime
+        } else if workTimerService.serviceState == .running {
+            let timeToTimerFinish: TimeInterval = workTimerService.remainingTime
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeToTimerFinish , repeats: false)
-            checkForPermissionAndDispatch(withTrigger: trigger)
+            checkForPermissionAndDispatch(withTrigger: trigger) // schedule notification for end of worktime
         }
     }
     

--- a/PunchPad/ViewModel/HomeViewModel.swift
+++ b/PunchPad/ViewModel/HomeViewModel.swift
@@ -184,6 +184,20 @@ extension HomeViewModel {
 
 //MARK: HANDLING BACKGROUND TIMER UPDATE FUNC
 extension HomeViewModel {
+    /// Set up combine subs to UI application background and foreground events
+    private func setAppStateObservers() {
+        NotificationCenter.default
+            .publisher(for: UIApplication.didEnterBackgroundNotification)
+            .sink { [weak self] _ in
+                self?.appDidEnterBackground()
+            }.store(in: &subscriptions)
+        
+        NotificationCenter.default
+            .publisher(for: UIApplication.willEnterForegroundNotification)
+            .sink { [weak self] _ in
+                self?.appWillEnterForeground()
+            }.store(in: &subscriptions)
+    }
     
     func resumeFromBackground(_ appDidEnterBackgroundDate: Date) {
         let timePassedInBackground = DateInterval(start: appDidEnterBackgroundDate, end: Date()).duration
@@ -205,10 +219,6 @@ extension HomeViewModel {
         }
     }
     
-    private func setAppStateObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
-    }
     
     @objc private func appDidEnterBackground() {
         if workTimerService.serviceState == .running {

--- a/PunchPadTests.xctestplan
+++ b/PunchPadTests.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "196AF9B2-9080-4E79-BF65-B17EDB57EBB2",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "HomeViewModelModelTests\/test_resumeFromBackground_withOneTimer_exceedingTimerLimit()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_withOneTimer_exceedingTimerLimit_savesEntry()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_withOneTimer_notExceedingTimerLimit()"
+      ],
+      "target" : {
+        "containerPath" : "container:PunchPad.xcodeproj",
+        "identifier" : "D6C4589F29D229230069D89B",
+        "name" : "PunchPadTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/PunchPadTests/HomeViewModelTests.swift
+++ b/PunchPadTests/HomeViewModelTests.swift
@@ -26,12 +26,15 @@ final class HomeViewModelModelTests: XCTestCase {
                                   timerProvider: MockTimer.self)
         )
     }
-
+    
     override func tearDown() {
         super.tearDown()
         sut = nil
     }
-    
+}
+
+//MARK: TIMER STATE CHANGE FUNCTIONS
+extension HomeViewModelModelTests {
     func test_startTimerService_when_noOvertime_firstRun() {
         //Given
         let expectedState: TimerService.TimerServiceState = .running
@@ -74,7 +77,7 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
         XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
     }
-
+    
     func test_timerProperties_notUpdating_whenPaused_noOvertime() {
         //Given
         setUpWithOneTimer()
@@ -88,7 +91,7 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.normalProgress, CGFloat(0.1), "Normal progress should be equal to 0.1")
         XCTAssertEqual(sut.overtimeProgress, CGFloat(0), "Overtime progress should be equal to 0")
     }
-
+    
     func test_resumeTimerService_whenPaused_noOvertime() {
         //Given
         let numberOfFires = 10
@@ -143,7 +146,7 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, accuracy: 0.01, "Normal progress should be equal to \(expectedNormalProgressValue)")
         XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
     }
-
+    
     func test_stopTimerService_stopsServiceAndSavesEntry_noOvertime() {
         //Given
         let numberOfExistingEntries = DataManager.testing.entryArray.count
@@ -360,7 +363,15 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .finished, "Service state should be finished")
         XCTAssertEqual(DataManager.testing.entryArray.count, expectedNumberOfEntries, "Additional entry should be saved")
     }
+}
+
+//MARK: BACKGROUND AND FOREGROUND TIMER UPDATES
+extension HomeViewModelModelTests {
     
+}
+
+//MARK: HELPERS
+extension HomeViewModelModelTests {
     private func setUpWithOneTimer() {
         settingsStore.isLoggingOvertime = false
         settingsStore.workTimeInSeconds = workTimerLimit

--- a/PunchPadTests/HomeViewModelTests.swift
+++ b/PunchPadTests/HomeViewModelTests.swift
@@ -428,7 +428,7 @@ extension HomeViewModelModelTests {
         XCTAssertEqual(DataManager.testing.entryArray.count, 0)
     }
     
-    func test_resumeFromBackground_withTwoTimers_ExceedingFirstTimerLimit() {
+    func test_resumeFromBackground_withTwoTimers_exceedingFirstTimerLimit() {
         //Given
         workTimerLimit = 2
         setUpWithTwoTimers()
@@ -440,6 +440,61 @@ extension HomeViewModelModelTests {
         //Then
         XCTAssertEqual(sut.normalProgress, 1, accuracy: 0.01)
         XCTAssertEqual(sut.overtimeProgress, 0.01, accuracy: 0.01)
+    }
+    
+    func test_resumeFromBackground_withTwoTimers_exceedingSecondTimer() {
+        //Given
+        workTimerLimit = 2
+        overtimeTimerLimit = 2
+        setUpWithTwoTimers()
+        let expectedStartTimeInterval = Date().timeIntervalSince1970
+        let expectedFinishTimeInterval = expectedStartTimeInterval + 4
+        let expectedEntriesCount = DataManager.testing.entryArray.count + 1
+        sut.startTimerService()
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        sleep(5)
+        //When
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        //Then
+        XCTAssertEqual(sut.normalProgress, 1, accuracy: 0.01)
+        XCTAssertEqual(sut.overtimeProgress, 1, accuracy: 0.01)
+        XCTAssertEqual(expectedEntriesCount, DataManager.testing.entryArray.count, "There should be additional entry in array")
+        guard let addedEntry = DataManager.testing.entryArray.first else {
+            XCTFail("Failed to retrieve expected entry in \(#function)")
+            return
+        }
+        XCTAssertEqual(addedEntry.startDate.timeIntervalSince1970, expectedStartTimeInterval, accuracy: 0.01)
+        XCTAssertEqual(addedEntry.finishDate.timeIntervalSince1970, expectedFinishTimeInterval, accuracy: 0.01)
+        XCTAssertEqual(addedEntry.workTimeInSeconds, 2)
+        XCTAssertEqual(addedEntry.overTimeInSeconds, 2)
+    }
+    
+    func test_resumeFromBackground_whenEnteredDuringSecondTimer_withTwoTimers_exceedingSecondTimer() {
+        //Given
+        workTimerLimit = 2
+        overtimeTimerLimit = 2
+        setUpWithTwoTimers()
+        let expectedStartTimeInterval = Date().timeIntervalSince1970
+        let expectedFinishTimeInterval = expectedStartTimeInterval + 4
+        let expectedEntriesCount = DataManager.testing.entryArray.count + 1
+        sut.startTimerService()
+        fireTimer(3)
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        sleep(5)
+        //When
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        //Then
+        XCTAssertEqual(sut.normalProgress, 1, accuracy: 0.01)
+        XCTAssertEqual(sut.overtimeProgress, 1, accuracy: 0.01)
+        XCTAssertEqual(expectedEntriesCount, DataManager.testing.entryArray.count, "There should be additional entry in array")
+        guard let addedEntry = DataManager.testing.entryArray.first else {
+            XCTFail("Failed to retrieve expected entry in \(#function)")
+            return
+        }
+        XCTAssertEqual(addedEntry.startDate.timeIntervalSince1970, expectedStartTimeInterval, accuracy: 0.01)
+        XCTAssertEqual(addedEntry.finishDate.timeIntervalSince1970, expectedFinishTimeInterval, accuracy: 0.01)
+        XCTAssertEqual(addedEntry.workTimeInSeconds, 2)
+        XCTAssertEqual(addedEntry.overTimeInSeconds, 2)
     }
 }
 


### PR DESCRIPTION
This PR solves issues when entering background and foreground. 

The notification part of home view model was refactored and redesigned to update the state of the app, timer services and properly save dates. 
Additional unit tests added 
Solved build issues with test targets leftover after Xcode renaming the project file 