### PR TITLE
35 notifications enhancement

### DIFF
--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		D684A38A2AF6F54B00511E0D /* ButtonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D684A3892AF6F54B00511E0D /* ButtonFactory.swift */; };
 		D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68732012B2243C9008CB0D4 /* PaginationState.swift */; };
 		D698F3F02B5C131D00D9DFF4 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D698F3EF2B5C131D00D9DFF4 /* NotificationService.swift */; };
+		D698F3F22B5C1F8600D9DFF4 /* AppNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D698F3F12B5C1F8600D9DFF4 /* AppNotification.swift */; };
 		D69C8CD72B43687700146EFA /* CustomDatePickerContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C8CD62B43687700146EFA /* CustomDatePickerContainer.swift */; };
 		D69C8CD92B44208C00146EFA /* ConfirmButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C8CD82B44208C00146EFA /* ConfirmButtonStyle.swift */; };
 		D69C8CDB2B4420D600146EFA /* CancelButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C8CDA2B4420D600146EFA /* CancelButtonStyle.swift */; };
@@ -197,6 +198,7 @@
 		D684A3892AF6F54B00511E0D /* ButtonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonFactory.swift; sourceTree = "<group>"; };
 		D68732012B2243C9008CB0D4 /* PaginationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationState.swift; sourceTree = "<group>"; };
 		D698F3EF2B5C131D00D9DFF4 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		D698F3F12B5C1F8600D9DFF4 /* AppNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNotification.swift; sourceTree = "<group>"; };
 		D69C8CD62B43687700146EFA /* CustomDatePickerContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePickerContainer.swift; sourceTree = "<group>"; };
 		D69C8CD82B44208C00146EFA /* ConfirmButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmButtonStyle.swift; sourceTree = "<group>"; };
 		D69C8CDA2B4420D600146EFA /* CancelButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelButtonStyle.swift; sourceTree = "<group>"; };
@@ -505,6 +507,7 @@
 				D682AF912B3C77F5004EE208 /* ChartTimeRange.swift */,
 				D6CA773E2B40BB4D00C98AF3 /* Route.swift */,
 				D698F3EF2B5C131D00D9DFF4 /* NotificationService.swift */,
+				D698F3F12B5C1F8600D9DFF4 /* AppNotification.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -693,6 +696,7 @@
 				D69C8CDB2B4420D600146EFA /* CancelButtonStyle.swift in Sources */,
 				D61F11312AB38F8700902D6D /* SettingsStore.swift in Sources */,
 				D6842EC029EC178000731E84 /* StatisticsView.swift in Sources */,
+				D698F3F22B5C1F8600D9DFF4 /* AppNotification.swift in Sources */,
 				D629CEF92B3613660036579D /* TimerService.swift in Sources */,
 				D66750EC29D71C8300757F17 /* HistoryRow.swift in Sources */,
 				D6EA695A2AF83E7800D8F6C3 /* OnboardingWorktimeView.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		D684A3882AF6F3E700511E0D /* OnboardingWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D684A3872AF6F3E700511E0D /* OnboardingWelcomeView.swift */; };
 		D684A38A2AF6F54B00511E0D /* ButtonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D684A3892AF6F54B00511E0D /* ButtonFactory.swift */; };
 		D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68732012B2243C9008CB0D4 /* PaginationState.swift */; };
+		D698F3F02B5C131D00D9DFF4 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D698F3EF2B5C131D00D9DFF4 /* NotificationService.swift */; };
 		D69C8CD72B43687700146EFA /* CustomDatePickerContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C8CD62B43687700146EFA /* CustomDatePickerContainer.swift */; };
 		D69C8CD92B44208C00146EFA /* ConfirmButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C8CD82B44208C00146EFA /* ConfirmButtonStyle.swift */; };
 		D69C8CDB2B4420D600146EFA /* CancelButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C8CDA2B4420D600146EFA /* CancelButtonStyle.swift */; };
@@ -195,6 +196,7 @@
 		D684A3872AF6F3E700511E0D /* OnboardingWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWelcomeView.swift; sourceTree = "<group>"; };
 		D684A3892AF6F54B00511E0D /* ButtonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonFactory.swift; sourceTree = "<group>"; };
 		D68732012B2243C9008CB0D4 /* PaginationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationState.swift; sourceTree = "<group>"; };
+		D698F3EF2B5C131D00D9DFF4 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		D69C8CD62B43687700146EFA /* CustomDatePickerContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePickerContainer.swift; sourceTree = "<group>"; };
 		D69C8CD82B44208C00146EFA /* ConfirmButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmButtonStyle.swift; sourceTree = "<group>"; };
 		D69C8CDA2B4420D600146EFA /* CancelButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelButtonStyle.swift; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 				D68732012B2243C9008CB0D4 /* PaginationState.swift */,
 				D682AF912B3C77F5004EE208 /* ChartTimeRange.swift */,
 				D6CA773E2B40BB4D00C98AF3 /* Route.swift */,
+				D698F3EF2B5C131D00D9DFF4 /* NotificationService.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -657,6 +660,7 @@
 				D6D02FB029EF0B7F006CD0B2 /* EditShetViewModel.swift in Sources */,
 				D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */,
 				D6FE20872B46EE0D00F931CD /* ConfirmDeleteRowView.swift in Sources */,
+				D698F3F02B5C131D00D9DFF4 /* NotificationService.swift in Sources */,
 				D6FA94FD2B013F060034B16A /* ChartLegendItemView.swift in Sources */,
 				D6E2C15B29D6C31800229286 /* HistoryViewModel.swift in Sources */,
 				D6EA695C2AF8452A00D8F6C3 /* TextFactory.swift in Sources */,

--- a/PunchPad/Model/AppNotification.swift
+++ b/PunchPad/Model/AppNotification.swift
@@ -6,3 +6,28 @@
 //
 
 import Foundation
+
+enum AppNotification {
+    case workTime
+    case overTime
+    
+    /// Title for the notification
+    var title: String {
+        switch self {
+        case .workTime:
+            return "Work finished!"
+        case .overTime:
+            return "Overtime finished!"
+        }
+    }
+    
+    /// Body message for notification
+    var body: String {
+        switch self {
+        case .workTime:
+            return "Congratulations! You are finished with your normal hours!"
+        case .overTime:
+            return "Congratulations! You finished with your overtime!"
+        }
+    }
+}

--- a/PunchPad/Model/AppNotification.swift
+++ b/PunchPad/Model/AppNotification.swift
@@ -1,0 +1,8 @@
+//
+//  AppNotification.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 20/01/2024.
+//
+
+import Foundation

--- a/PunchPad/Model/Container.swift
+++ b/PunchPad/Model/Container.swift
@@ -14,6 +14,7 @@ class Container: ObservableObject {
     private(set) var payManager: PayManager
     private(set) var timerProvider: Timer.Type
     private(set) var settingsStore: SettingsStore
+    private(set) var notificationService: NotificationService
     
     private enum ContainerType {
         case production, test, preview
@@ -50,5 +51,6 @@ class Container: ObservableObject {
             self.dataManager = .preview
             self.payManager = PayManager(dataManager: .preview, settingsStore: settingsStore)
         }
+        self.notificationService = NotificationService(center: .current())
     }
 }

--- a/PunchPad/Model/NotificationService.swift
+++ b/PunchPad/Model/NotificationService.swift
@@ -33,6 +33,20 @@ class NotificationService {
         pendingNotificationsIDs.removeAll()
     }
     
+    func checkForAuthorization() async -> Bool? {
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .notDetermined:
+            return nil
+        case .denied:
+            return false
+        case .authorized, .provisional, .ephemeral:
+            return true
+        @unknown default:
+            return nil
+        }
+    }
+    
     func scheduleNotification(for notification: AppNotification, in timeInterval: TimeInterval) {
         let id = UUID().uuidString
         

--- a/PunchPad/Model/NotificationService.swift
+++ b/PunchPad/Model/NotificationService.swift
@@ -19,9 +19,7 @@ class NotificationService {
     func requestAuthorizationForNotifications(failureHandler: @escaping (Bool, Error?) -> Void) {
         center.requestAuthorization(options: [.alert, .sound, .badge]) { success, error in
             if !success {
-                print("User declined notification")
-                // setting in store should be false
-                failureHandler(success, error) // <- this happens when user does not accept the notifications
+                failureHandler(success, error)
             }
             if let error {
                 print(error.localizedDescription)
@@ -44,6 +42,24 @@ class NotificationService {
             return true
         @unknown default:
             return nil
+        }
+    }
+    
+    func checkForAuthorization(completionHandler: @escaping (Bool?) -> Void) {
+        center.getNotificationSettings { settings in
+            let value: Bool? = {
+                switch settings.authorizationStatus {
+                case .notDetermined:
+                    return nil
+                case .denied:
+                    return false
+                case .authorized, .provisional, .ephemeral:
+                    return true
+                @unknown default:
+                    return nil
+                }
+            }()
+            completionHandler(value)
         }
     }
     

--- a/PunchPad/Model/NotificationService.swift
+++ b/PunchPad/Model/NotificationService.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationService.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 20/01/2024.
+//
+
+import Foundation
+
+class NotificationService {
+    
+}

--- a/PunchPad/Model/NotificationService.swift
+++ b/PunchPad/Model/NotificationService.swift
@@ -19,6 +19,7 @@ class NotificationService {
     func requestAuthorizationForNotifications(failureHandler: @escaping (Bool, Error?) -> Void) {
         center.requestAuthorization(options: [.alert, .sound, .badge]) { success, error in
             if !success {
+                print("User declined notification")
                 // setting in store should be false
                 failureHandler(success, error) // <- this happens when user does not accept the notifications
             }
@@ -29,6 +30,7 @@ class NotificationService {
     }
     func deschedulePendingNotifications() {
         center.removeAllPendingNotificationRequests()
+        pendingNotificationsIDs.removeAll()
     }
     
     func scheduleNotification(for notification: AppNotification, in timeInterval: TimeInterval) {
@@ -39,6 +41,7 @@ class NotificationService {
         let notificationContent = UNMutableNotificationContent()
         notificationContent.title = notification.title
         notificationContent.body = notification.body
+        notificationContent.interruptionLevel = .active
         
         let request = UNNotificationRequest(identifier: id,
                                             content: notificationContent,
@@ -46,7 +49,7 @@ class NotificationService {
         checkForPermissionAndDispatch(request)
     }
     
-    func checkForPermissionAndDispatch(_ notificationRequest: UNNotificationRequest) {
+    private func checkForPermissionAndDispatch(_ notificationRequest: UNNotificationRequest) {
         center.getNotificationSettings { settings in
             switch settings.authorizationStatus {
             case .authorized:
@@ -57,7 +60,7 @@ class NotificationService {
         }
     }
     
-    func dispatch(notification: UNNotificationRequest) {
+    private func dispatch(notification: UNNotificationRequest) {
         _ = pendingNotificationsIDs.insert(notification.identifier)
         center.add(notification)
     }

--- a/PunchPad/Model/NotificationService.swift
+++ b/PunchPad/Model/NotificationService.swift
@@ -6,7 +6,60 @@
 //
 
 import Foundation
+import UserNotifications
 
 class NotificationService {
+    let center: UNUserNotificationCenter
+    var pendingNotificationsIDs: Set<String> = []
+    
+    init(center: UNUserNotificationCenter) {
+        self.center = center
+    }
+    
+    func requestAuthorizationForNotifications(failureHandler: @escaping (Bool, Error?) -> Void) {
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { success, error in
+            if !success {
+                // setting in store should be false
+                failureHandler(success, error) // <- this happens when user does not accept the notifications
+            }
+            if let error {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    func deschedulePendingNotifications() {
+        center.removeAllPendingNotificationRequests()
+    }
+    
+    func scheduleNotification(for notification: AppNotification, in timeInterval: TimeInterval) {
+        let id = UUID().uuidString
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
+        
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.title = notification.title
+        notificationContent.body = notification.body
+        
+        let request = UNNotificationRequest(identifier: id,
+                                            content: notificationContent,
+                                            trigger: trigger)
+        checkForPermissionAndDispatch(request)
+    }
+    
+    func checkForPermissionAndDispatch(_ notificationRequest: UNNotificationRequest) {
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .authorized:
+                self.dispatch(notification: notificationRequest)
+            default:
+                return
+            }
+        }
+    }
+    
+    func dispatch(notification: UNNotificationRequest) {
+        _ = pendingNotificationsIDs.insert(notification.identifier)
+        center.add(notification)
+    }
     
 }

--- a/PunchPad/View/ContentView.swift
+++ b/PunchPad/View/ContentView.swift
@@ -36,7 +36,10 @@ struct ContentView: View {
         .fullScreenCover(isPresented: $isRunFirstTime, onDismiss: {
             isRunFirstTime = false
         }) {
-            OnboardingView(viewModel: OnboardingViewModel(settingsStore: container.settingsStore))
+            OnboardingView(viewModel: 
+                            OnboardingViewModel(notificationService: container.notificationService,
+                                                settingsStore: container.settingsStore)
+            )
         }
         
     }

--- a/PunchPad/View/ContentView.swift
+++ b/PunchPad/View/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
                 SettingsView(viewModel:
                                 SettingsViewModel(
                                     dataManger: container.dataManager,
+                                    notificationService: container.notificationService,
                                     settingsStore: container.settingsStore
                                 )
                 )

--- a/PunchPad/View/HomeView.swift
+++ b/PunchPad/View/HomeView.swift
@@ -156,7 +156,8 @@ struct Home_Previews: PreviewProvider {
                         HomeViewModel(
                             dataManager: container.dataManager,
                             settingsStore: container.settingsStore,
-                            payManager: container.payManager,
+                            payManager: container.payManager, 
+                            notificationService: container.notificationService,
                             timerProvider: container.timerProvider
                         )
             )

--- a/PunchPad/View/MainView.swift
+++ b/PunchPad/View/MainView.swift
@@ -41,6 +41,7 @@ struct MainView: View {
                                         HomeViewModel(dataManager: container.dataManager,
                                                       settingsStore: container.settingsStore,
                                                       payManager: container.payManager,
+                                                      notificationService: container.notificationService,
                                                       timerProvider: container.timerProvider)
         )
         

--- a/PunchPad/View/OboardingViews/OnboardingNotificationView.swift
+++ b/PunchPad/View/OboardingViews/OnboardingNotificationView.swift
@@ -16,7 +16,6 @@ struct OnboardingNotificationView: View {
     let alertMessage: String = "You need to allow for notification in settings"
     let alertButtonText: String = "OK"
     @ObservedObject var viewModel: OnboardingViewModel
-    @State private var showAlert: Bool = false
     
     var body: some View {
         VStack(spacing: 40) {
@@ -25,29 +24,18 @@ struct OnboardingNotificationView: View {
             TextFactory.buildDescription(descriptionText)
             
             Toggle("Send notifications on finish", isOn: $viewModel.settingsStore.isSendingNotification)
-                .disabled(viewModel.authorizationDenied)
                 .foregroundColor(.theme.blackLabel)
                 .tint(.theme.primary)
                 .accessibilityIdentifier(Identifier.Toggles.notifications.rawValue)
                 .padding()
                 .background()
                 .cornerRadius(20)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 20)
-                        .foregroundColor(
-                            viewModel.authorizationDenied ? 
-                            Color.white.opacity(0.1) : Color.clear
-                        )
-                        .onTapGesture {
-                            showAlert.toggle()
-                        }
-                }
         }
         .padding(30)
         .alert(alertTitle,
-               isPresented: $showAlert) {
+               isPresented: $viewModel.shouldShowNotificationDeniedAlert) {
             Button(alertButtonText) {
-                showAlert.toggle()
+                viewModel.shouldShowNotificationDeniedAlert = false
             }
         } message: {
             Text(alertMessage)

--- a/PunchPad/View/OboardingViews/OnboardingNotificationView.swift
+++ b/PunchPad/View/OboardingViews/OnboardingNotificationView.swift
@@ -41,7 +41,8 @@ struct OnboardingNotification_Preview: PreviewProvider {
         init() {
             let container = Container()
             self._container = StateObject(wrappedValue: container)
-            self._vm = StateObject(wrappedValue: OnboardingViewModel(settingsStore: container.settingsStore))
+            self._vm = StateObject(wrappedValue: OnboardingViewModel(notificationService: container.notificationService,
+                                                                     settingsStore: container.settingsStore))
         }
         
         var body: some View {

--- a/PunchPad/View/OboardingViews/OnboardingNotificationView.swift
+++ b/PunchPad/View/OboardingViews/OnboardingNotificationView.swift
@@ -12,7 +12,11 @@ struct OnboardingNotificationView: View {
     private typealias Identifier = ScreenIdentifier.OnboardingView
     let titleText: String = "Notifications"
     let descriptionText: String = "Do you want PunchPad to send you notifications when the work time is finished?"
+    let alertTitle: String = "PunchPad needs permission to show notifications"
+    let alertMessage: String = "You need to allow for notification in settings"
+    let alertButtonText: String = "OK"
     @ObservedObject var viewModel: OnboardingViewModel
+    @State private var showAlert: Bool = false
     
     var body: some View {
         VStack(spacing: 40) {
@@ -21,14 +25,33 @@ struct OnboardingNotificationView: View {
             TextFactory.buildDescription(descriptionText)
             
             Toggle("Send notifications on finish", isOn: $viewModel.settingsStore.isSendingNotification)
+                .disabled(viewModel.authorizationDenied)
                 .foregroundColor(.theme.blackLabel)
                 .tint(.theme.primary)
                 .accessibilityIdentifier(Identifier.Toggles.notifications.rawValue)
                 .padding()
                 .background()
                 .cornerRadius(20)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 20)
+                        .foregroundColor(
+                            viewModel.authorizationDenied ? 
+                            Color.white.opacity(0.1) : Color.clear
+                        )
+                        .onTapGesture {
+                            showAlert.toggle()
+                        }
+                }
         }
         .padding(30)
+        .alert(alertTitle,
+               isPresented: $showAlert) {
+            Button(alertButtonText) {
+                showAlert.toggle()
+            }
+        } message: {
+            Text(alertMessage)
+        }
     }
 }
 
@@ -41,8 +64,11 @@ struct OnboardingNotification_Preview: PreviewProvider {
         init() {
             let container = Container()
             self._container = StateObject(wrappedValue: container)
-            self._vm = StateObject(wrappedValue: OnboardingViewModel(notificationService: container.notificationService,
-                                                                     settingsStore: container.settingsStore))
+            self._vm = StateObject(wrappedValue: 
+                                    OnboardingViewModel(
+                                        notificationService: container.notificationService,
+                                        settingsStore: container.settingsStore)
+            )
         }
         
         var body: some View {

--- a/PunchPad/View/OboardingViews/OnboardingOvertimeView.swift
+++ b/PunchPad/View/OboardingViews/OnboardingOvertimeView.swift
@@ -102,7 +102,8 @@ struct OnbardingOvertime_Previews: PreviewProvider {
         init() {
             let container = Container()
             self._container = StateObject(wrappedValue: container)
-            self._vm = StateObject(wrappedValue: OnboardingViewModel(settingsStore: container.settingsStore))
+            self._vm = StateObject(wrappedValue: OnboardingViewModel(notificationService: container.notificationService, 
+                                                                     settingsStore: container.settingsStore))
         }
         
         var body: some View {

--- a/PunchPad/View/OboardingViews/OnboardingSalaryView.swift
+++ b/PunchPad/View/OboardingViews/OnboardingSalaryView.swift
@@ -76,7 +76,10 @@ struct OnboardingSalary_Preview: PreviewProvider {
         init() {
             let container = Container()
             self._container = StateObject(wrappedValue: container)
-            self._vm = StateObject(wrappedValue: OnboardingViewModel(settingsStore: container.settingsStore))
+            self._vm = StateObject(wrappedValue: 
+                                    OnboardingViewModel(notificationService: container.notificationService,
+                                                        settingsStore: container.settingsStore)
+            )
         }
         
         var body: some View {

--- a/PunchPad/View/OboardingViews/OnboardingWorktimeView.swift
+++ b/PunchPad/View/OboardingViews/OnboardingWorktimeView.swift
@@ -79,7 +79,10 @@ struct OnbardingWorktime_Previews: PreviewProvider {
         init() {
             let container = Container()
             self._container = StateObject(wrappedValue: container)
-            self._vm = StateObject(wrappedValue: OnboardingViewModel(settingsStore: container.settingsStore))
+            self._vm = StateObject(wrappedValue: 
+                                    OnboardingViewModel(notificationService: container.notificationService,
+                                                        settingsStore: container.settingsStore)
+            )
         }
         
         var body: some View {

--- a/PunchPad/View/OnboardingView.swift
+++ b/PunchPad/View/OnboardingView.swift
@@ -103,8 +103,14 @@ extension OnboardingView {
     }
 }
 
-struct OnboardingView_Previews: PreviewProvider {
-    static var previews: some View {
-        OnboardingView(viewModel: OnboardingViewModel(settingsStore: SettingsStore()))
+#Preview {
+    struct ContainerView: View {
+        @StateObject private var container: Container = Container()
+        var body: some View {
+            OnboardingView(viewModel:
+                            OnboardingViewModel(notificationService: container.notificationService,
+                                                settingsStore: container.settingsStore))
+        }
     }
+    return ContainerView()
 }

--- a/PunchPad/View/SettingsView.swift
+++ b/PunchPad/View/SettingsView.swift
@@ -14,11 +14,14 @@ struct SettingsView: View {
     @StateObject private var viewModel: SettingsViewModel
     @State private var isShowingWorkTimeEditor: Bool = false
     @State private var isShowingOvertimeEditor: Bool = false
+    @State private var isShowingAlert: Bool = false
     
     init(viewModel: SettingsViewModel) {
         self._viewModel = StateObject.init(wrappedValue: viewModel)
     }
-    
+    let alertTitle: String = "PunchPad needs permission to show notifications"
+    let alertMessage: String = "You need to allow for notification in settings"
+    let alertButtonText: String = "OK"
     let navigationTitleText: String = "Settings"
     let hoursPickerText: String = "Hours"
     let minutesPickerText: String = "Minutes"
@@ -63,6 +66,15 @@ extension SettingsView {
                                   isOn: $viewModel.settingsStore.isSendingNotification,
                                   identifier: .sendNotificationsOnFinish
                     )
+                    .disabled(viewModel.authorizationDenied)
+                    .overlay {
+                        Color.white
+                            .opacity(viewModel.authorizationDenied ?
+                                     0.1 : 0)
+                            .onTapGesture {
+                                isShowingAlert.toggle()
+                            }
+                    }
                 } header: {
                     TextFactory.buildSectionHeader(timerSettingsHeaderText)
                         .accessibilityIdentifier(Identifier.SectionHeaders.timerSettings.rawValue)
@@ -104,6 +116,15 @@ extension SettingsView {
             
         } // END OF ZSTACK
         .navigationBarTitle("Settings")
+        .alert(alertTitle,
+               isPresented: $isShowingAlert) {
+            Button(alertButtonText) {
+                isShowingAlert.toggle()
+            }
+        } message: {
+            Text(alertMessage)
+        }
+
     } // END OF BODY
     
     var timerSettings: some View {

--- a/PunchPad/View/SettingsView.swift
+++ b/PunchPad/View/SettingsView.swift
@@ -298,7 +298,11 @@ struct SettingsView_Previews: PreviewProvider {
     private struct ContainerView: View {
         @StateObject private var container = Container()
         var body: some View {
-                SettingsView(viewModel: SettingsViewModel(dataManger: container.dataManager, settingsStore: container.settingsStore))
+            SettingsView(viewModel: 
+                            SettingsViewModel(dataManger: container.dataManager,
+                                              notificationService: container.notificationService,
+                                              settingsStore: container.settingsStore)
+            )
         }
     }
     static var previews: some View {

--- a/PunchPad/View/SettingsView.swift
+++ b/PunchPad/View/SettingsView.swift
@@ -14,7 +14,6 @@ struct SettingsView: View {
     @StateObject private var viewModel: SettingsViewModel
     @State private var isShowingWorkTimeEditor: Bool = false
     @State private var isShowingOvertimeEditor: Bool = false
-    @State private var isShowingAlert: Bool = false
     
     init(viewModel: SettingsViewModel) {
         self._viewModel = StateObject.init(wrappedValue: viewModel)
@@ -66,15 +65,6 @@ extension SettingsView {
                                   isOn: $viewModel.settingsStore.isSendingNotification,
                                   identifier: .sendNotificationsOnFinish
                     )
-                    .disabled(viewModel.authorizationDenied)
-                    .overlay {
-                        Color.white
-                            .opacity(viewModel.authorizationDenied ?
-                                     0.1 : 0)
-                            .onTapGesture {
-                                isShowingAlert.toggle()
-                            }
-                    }
                 } header: {
                     TextFactory.buildSectionHeader(timerSettingsHeaderText)
                         .accessibilityIdentifier(Identifier.SectionHeaders.timerSettings.rawValue)
@@ -117,9 +107,9 @@ extension SettingsView {
         } // END OF ZSTACK
         .navigationBarTitle("Settings")
         .alert(alertTitle,
-               isPresented: $isShowingAlert) {
+               isPresented: $viewModel.shouldShowNotificationDeniedAlert) {
             Button(alertButtonText) {
-                isShowingAlert.toggle()
+                viewModel.shouldShowNotificationDeniedAlert = false 
             }
         } message: {
             Text(alertMessage)

--- a/PunchPad/ViewModel/OnboardingViewModel.swift
+++ b/PunchPad/ViewModel/OnboardingViewModel.swift
@@ -12,6 +12,7 @@ import UserNotifications
 class OnboardingViewModel: ObservableObject {
     
     private var subscriptions = Set<AnyCancellable>()
+    private var notificationService: NotificationService
     @Published var settingsStore: SettingsStore
     @Published var grossPayPerMonthText: Int
     @Published var hoursWorking: Int
@@ -19,7 +20,8 @@ class OnboardingViewModel: ObservableObject {
     @Published var hoursOvertime: Int
     @Published var minutesOvertime: Int
     
-    init(settingsStore: SettingsStore) {
+    init(notificationService: NotificationService, settingsStore: SettingsStore) {
+        self.notificationService = notificationService
         self.settingsStore = settingsStore
         self.hoursWorking = settingsStore.workTimeInSeconds / 3600
         self.minutesWorking = (settingsStore.workTimeInSeconds % 3600) / 60
@@ -77,14 +79,8 @@ class OnboardingViewModel: ObservableObject {
     }
     
     func requestAuthorizationForNotifications() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge], completionHandler: { [weak self] success, error in
-            if success {
-                print("Autorization success")
-            } else if let error = error {
-                print(error.localizedDescription)
-                guard let self else { return }
-                self.settingsStore.isSendingNotification = false
-            }
-        })
+        notificationService.requestAuthorizationForNotifications { [weak self] result, error in
+            self?.settingsStore.isSendingNotification = result
+        }
     }
 }

--- a/PunchPad/ViewModel/SettingViewModel.swift
+++ b/PunchPad/ViewModel/SettingViewModel.swift
@@ -18,6 +18,7 @@ class SettingsViewModel: ObservableObject {
     @Published var overtimeHours: Int
     @Published var overtimeMinutes: Int
     @Published var grossPayPerMonth: Int
+    @Published var authorizationDenied: Bool = true
     
     init(dataManger: DataManager, notificationService: NotificationService, settingsStore: SettingsStore) {
         self.dataManager = dataManger
@@ -28,6 +29,9 @@ class SettingsViewModel: ObservableObject {
         self.overtimeHours = settingsStore.maximumOvertimeAllowedInSeconds / 3600
         self.overtimeMinutes = (settingsStore.maximumOvertimeAllowedInSeconds % 3600) / 60
         self.grossPayPerMonth = settingsStore.grossPayPerMonth
+        notificationService.checkForAuthorization { [weak self] optionalValue in
+                self?.authorizationDenied = !(optionalValue ?? true)
+        }
         setSubscribers()
     }
     


### PR DESCRIPTION
This PR solves issue #35. To better organise and help solve the issue logic related to scheduling, descheduling, authorising and checking authorisation, existing logic was refactored from view models to a new service. User is now not able to set notifications on, if the app is not authorised. 

Added:
- Added NotificationService
- Added AppNotification 

Changed:
- Changed scheduling notifications in home view 
- Changed authorisation of notifications in onboarding view 
- Changed authorisation and status checking in settings view 