### PR TITLE
Fix issue where currentMaximumOvertime would be saved as srandard wor…

### DIFF
--- a/PunchPad/ViewModel/EditShetViewModel.swift
+++ b/PunchPad/ViewModel/EditShetViewModel.swift
@@ -243,7 +243,7 @@ final class EditSheetViewModel: ObservableObject {
         entry.workTimeInSeconds = Int(workTimeInSeconds)
         entry.overTimeInSeconds = Int(overTimeInSeconds)
         entry.maximumOvertimeAllowedInSeconds = Int(currentMaximumOvertime)
-        entry.standardWorktimeInSeconds = Int(currentMaximumOvertime)
+        entry.standardWorktimeInSeconds = Int(currentStandardWorkTime)
         entry.grossPayPerMonth = grossPayPerMonth
         entry.calculatedNetPay = calculateNetPay ? payService.calculateNetPay(gross: Double(grossPayPerMonth)) : nil
         dataManager.updateAndSave(entry: entry)


### PR DESCRIPTION
This PR addresses issue #40. Issue was tracked to improper saving of standardWorkTimeInSeconds in entry edit sheet view.
Issue was fixed by using proper views model property on save.