### PR TITLE
39 unclear interpretation of time when break present in workday

### DIFF
--- a/PunchPad/View/EditSheetView.swift
+++ b/PunchPad/View/EditSheetView.swift
@@ -16,6 +16,7 @@ struct EditSheetView: View {
     private typealias Identifier = ScreenIdentifier.EditSheetView
     let regularTimeText: String = "Regular time"
     let overtimeText: String = "Overtime"
+    let breaktimeText: String = "Break time"
     let titleText: String = "Edit entry"
     let timeIndicatorText: String = "work time"
     let overrideSettingsHeaderText: String = "Override settings"
@@ -71,6 +72,8 @@ extension EditSheetView {
                 regularTimeLabel
                 Spacer()
                 overtimeLabel
+                Spacer()
+                breakTimeLabel
             }
         }
     }
@@ -84,21 +87,33 @@ extension EditSheetView {
     }
     
     var overtimeLabel: some View {
-            HStack {
+            VStack {
                 Text(generateTimeIntervalLabel(value: viewModel.overTimeInSeconds))
                     .font(.title)
                 Text(overtimeText)
                     .font(.caption)
             }
+            .foregroundColor(.theme.black)
     }
     
     var regularTimeLabel: some View {
-            HStack {
+            VStack {
                 Text(generateTimeIntervalLabel(value: viewModel.workTimeInSeconds))
                     .font(.title)
                 Text(regularTimeText)
                     .font(.caption)
             }
+            .foregroundColor(.theme.black)
+    }
+    
+    var breakTimeLabel: some View {
+        VStack {
+            Text(generateTimeIntervalLabel(value: viewModel.breakTime))
+                .font(.title)
+            Text(breaktimeText)
+                .font(.caption)
+        }
+        .foregroundColor(.theme.black)
     }
     
     private func generateTimeIntervalLabel(value: TimeInterval) -> String {

--- a/PunchPad/ViewModel/EditShetViewModel.swift
+++ b/PunchPad/ViewModel/EditShetViewModel.swift
@@ -28,6 +28,14 @@ final class EditSheetViewModel: ObservableObject {
     var totalTimeInSeconds: TimeInterval {
         TimeInterval(workTimeInSeconds + overTimeInSeconds)
     }
+    var breakTime: TimeInterval {
+        let timeFromDates = DateInterval(start: startDate, end: finishDate).duration
+        if timeFromDates > workTimeInSeconds + overTimeInSeconds {
+            return timeFromDates - workTimeInSeconds - overTimeInSeconds
+        } else {
+            return 0
+        }
+    }
     var workTimeFraction: CGFloat {
         CGFloat(workTimeInSeconds / currentStandardWorkTime)
     }


### PR DESCRIPTION
This PR solves issue raised by a beta tester (issue #39) - unclear interpretation of time when break was present in a workday. 

To solve this issue in edit sheet view additional label was added driven by a computed property in view model. 
View model property is computed by creating a date interval, and using it duration to establish if there is a difference between sum of work time and overtime, and if the date interval duration is bigger than sum of work and over time, it returns the difference. 

This allows for a simple way to inform the user that the application is working as intended and the difference between start-finish time and logged time is correct.