### PR TITLE
41 implement manual date controls in editing

### DIFF
--- a/PunchPad/View/EditSheetView.swift
+++ b/PunchPad/View/EditSheetView.swift
@@ -29,8 +29,6 @@ struct EditSheetView: View {
     let grossPayPerMonthText = "Gross pay per month"
     let calculateNetPayText = "Calculate net pay"
     let dateComponentFormatter = FormatterFactory.makeHourAndMinuteDateComponentFormatter()
-    
-    
 } // END OF STRUCT
 
 //MARK: BODY
@@ -139,17 +137,18 @@ extension EditSheetView {
                     .labelsHidden()
                     .accessibilityIdentifier(Identifier.DatePicker.startDate.rawValue)
             } trailing: {
-                imageCalendar
+               calendarToggable
             }
             .frame(height: 50)
             .padding(.top)
+            .padding(.bottom, 2)
             
             CustomDatePickerContainer(labelText: finishDateText) {
                 DatePicker(finishDateText, selection: $viewModel.finishDate, in: PartialRangeFrom(viewModel.startDate))
                     .labelsHidden()
                     .accessibilityIdentifier(Identifier.DatePicker.finishDate.rawValue)
             } trailing: {
-                imageCalendar
+                calendarToggable
             }
             .frame(height: 50)
             .padding(.bottom)
@@ -159,17 +158,18 @@ extension EditSheetView {
     
     var sameDayDateControls: some View {
         Group {
-            CustomDatePickerContainer(labelText: nil) {
+            CustomDatePickerContainer(labelText: "Date") {
                 DatePicker(selection: $viewModel.startDate,
                            displayedComponents: .date) {
                     EmptyView()
                 }
                            .labelsHidden()
             } trailing: {
-                imageCalendar
+                calendarToggable
             }
             .frame(height: 50)
             .padding(.top)
+            .padding(.bottom, 2)
             HStack {
                 CustomDatePickerContainer(labelText: startDateText) {
                     DatePicker(selection: $viewModel.startDate,
@@ -319,6 +319,15 @@ extension EditSheetView {
         Image(systemName: "clock")
             .font(.title)
             .foregroundColor(.theme.primary)
+    }
+    
+    var calendarToggable: some View {
+        imageCalendar
+            .onTapGesture {
+                withAnimation {
+                    viewModel.shouldDisplayFullDates.toggle()
+                }
+            }
     }
     
     var imageCalendar: some View {

--- a/PunchPad/ViewModel/EditShetViewModel.swift
+++ b/PunchPad/ViewModel/EditShetViewModel.swift
@@ -68,10 +68,10 @@ final class EditSheetViewModel: ObservableObject {
             return false
         }()
         // set up combine pipelines
-        setDateMatchingPipeline()
         setTimeCalculationPipelines()
         setOverrideTimePipelines()
-        setDisplayingFullDatesPipeline()
+//        setDateMatchingPipeline()
+//        setDisplayingFullDatesPipeline()
     }
     
     private func setOverrideTimePipelines() {

--- a/PunchPad/ViewModel/EditShetViewModel.swift
+++ b/PunchPad/ViewModel/EditShetViewModel.swift
@@ -60,12 +60,12 @@ final class EditSheetViewModel: ObservableObject {
         self.calculateNetPay = entry.calculatedNetPay == nil ? false : true
         
         self.shouldDisplayFullDates = {
-            if let hours = calendar.dateComponents([.hour], from: entry.startDate).hour {
-                if hours >= 24 - (entry.standardWorktimeInSeconds / 3600) {
-                            return true
-                        }
-                    }
-            return false
+            let startDateComponents = calendar.dateComponents([.year, .month, .day], from: entry.startDate)
+            if calendar.date(entry.finishDate, matchesComponents: startDateComponents) {
+                return false
+            } else {
+                return true
+            }
         }()
         // set up combine pipelines
         setTimeCalculationPipelines()


### PR DESCRIPTION
This PR reworks the controls for date in EntrySheetView. EditSheetView has two different view components controlling start and finish date. Each view components consists of date pickers for both start and finish date. 
sameDayDateControls view component consists of date pickers:
- start date picker displaying date
- start date picker displaying time
- finish date picker displaying time 
diffDayDateControls view component consists of date pickers:
- start date picker displaying date and time 
- finish date picker displaying date and time 

Previously the way that date controls were displayed was controlled by the amount of hours till finish of the start day. If the standard working time was larger than remaining part of the day, different day controls were displayed. If the date was adjusted to the same date, single date controls were displayed.

This approach was confusing for the user and did not give good feedback. Simpler solution was implemented where tapping on any of the calendar icons in date section is switching the date controls view displayed. 