### PR TITLE
43 incorrect display of chart range when 1 year period displayed

### DIFF
--- a/PunchPad/Factory/FormatterFactory.swift
+++ b/PunchPad/Factory/FormatterFactory.swift
@@ -56,6 +56,27 @@ struct FormatterFactory {
         return formatter
     }
     
+    /// Returns `DateFormatter` with date style displaying full month name - `January` and 4 digit year `1999`, with no time components
+    static func makeFullMonthYearDateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter
+    }
+    
+    /// Returns `DateFormatter` with date style displaying 4 digit year `1999`, with no time components
+    static func makeYearDateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy"
+        return formatter
+    }
+    
+    /// Returns `DateFormatter` with date style displaying 1 or 2 digit day of the month, with no time components
+    static func makeDayDateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "dd"
+        return formatter
+    }
+    
     static func makeCurrencyFormatter(_ locale: Locale) -> NumberFormatter {
         let formatter = NumberFormatter()
         formatter.locale = locale

--- a/PunchPad/View/StatisticsView.swift
+++ b/PunchPad/View/StatisticsView.swift
@@ -149,17 +149,32 @@ extension StatisticsView {
     } // END OF VAR
     
     func makePeriodRangeString(for period: Period) -> String {
-        let periodEndMonth = Calendar.current.dateComponents([.month], from: period.1)
-        let periodEndYear = Calendar.current.dateComponents([.year], from: period.1)
-        let isSameMonth = Calendar.current.date(period.0, matchesComponents: periodEndMonth)
-        if isSameMonth {
-            let startDay = Calendar.current.dateComponents([.day], from: period.0)
-            return "\(startDay.day ?? 0) - \(period.1.formatted(date: .abbreviated, time: .omitted))"
-        }
-        let isSameYear = Calendar.current.date(period.0, matchesComponents: periodEndYear)
-        if isSameYear {
-            let startString = String(period.0.formatted(date: .abbreviated, time: .omitted).dropLast(5))
-            return startString + " - " + period.1.formatted(date: .abbreviated, time: .omitted)
+        let number = Calendar.current.dateComponents([.day], from: period.0, to: period.1).day!
+        if number <= 7 {
+            // this works well for week
+            let periodEndMonth = Calendar.current.dateComponents([.month], from: period.1)
+            let periodEndYear = Calendar.current.dateComponents([.year], from: period.1)
+            let isSameMonth = Calendar.current.date(period.0, matchesComponents: periodEndMonth)
+            
+            if isSameMonth {
+                let startDay = Calendar.current.dateComponents([.day], from: period.0)
+                return "\(startDay.day ?? 0) - \(period.1.formatted(date: .abbreviated, time: .omitted))"
+            }
+            let isSameYear = Calendar.current.date(period.0, matchesComponents: periodEndYear)
+            if isSameYear {
+                let startString = String(period.0.formatted(date: .abbreviated, time: .omitted).dropLast(5))
+                return startString + " - " + period.1.formatted(date: .abbreviated, time: .omitted)
+            }
+        } else if number <= 31 {
+            // this is a month
+            let startDateComponents = Calendar.current.dateComponents([.month, .year], from: period.0)
+            let formatter = DateFormatter()
+            formatter.dateFormat = "MMMM yyyy"
+            return formatter.string(from: period.0)
+        } else if number <= 366 {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy"
+            return formatter.string(from: period.0)
         }
         return period.0.formatted(date: .abbreviated, time: .omitted) + " - " + period.1.formatted(date: .abbreviated, time: .omitted)
     }


### PR DESCRIPTION
This PR is to address issue #47. 

In this PR function responsible for building period time range description for charts and pay card in statistics view was updated to:
- display correctly when month or year time range is chosen
- replace manual formatting with use of DateFormatters 
Additional date formatter generating functions were added to FormatterFactory
