### PR TITLE
38 gross pay check on stats screen shows inconsistent results

### DIFF
--- a/PunchPad/Model/Container.swift
+++ b/PunchPad/Model/Container.swift
@@ -43,13 +43,13 @@ class Container: ObservableObject {
         switch containerType {
         case .production:
             self.dataManager = .shared
-            self.payManager = PayManager(dataManager: .shared, settingsStore: settingsStore)
+            self.payManager = PayManager(dataManager: .shared, settingsStore: settingsStore, calendar: .current)
         case .test:
             self.dataManager = .testing
-            self.payManager = PayManager(dataManager: .testing, settingsStore: settingsStore)
+            self.payManager = PayManager(dataManager: .testing, settingsStore: settingsStore, calendar: .current)
         case .preview:
             self.dataManager = .preview
-            self.payManager = PayManager(dataManager: .preview, settingsStore: settingsStore)
+            self.payManager = PayManager(dataManager: .preview, settingsStore: settingsStore, calendar: .current)
         }
         self.notificationService = NotificationService(center: .current())
     }

--- a/PunchPadTests/EditSheetViewModelTests.swift
+++ b/PunchPadTests/EditSheetViewModelTests.swift
@@ -34,7 +34,7 @@ final class EditSheetViewModelTests: XCTestCase {
         
         sut = .init(dataManager: .testing,
                     settingsStore: settingStore,
-                    payService: PayManager(dataManager: .testing, settingsStore: settingStore),
+                    payService: PayManager(dataManager: .testing, settingsStore: settingStore, calendar: .current),
                     calendar: .current,
                     entry: entry)
     }

--- a/PunchPadTests/HomeViewModelTests.swift
+++ b/PunchPadTests/HomeViewModelTests.swift
@@ -22,7 +22,9 @@ final class HomeViewModelModelTests: XCTestCase {
         DataManager.testing.deleteAll()
         sut = .init(HomeViewModel(dataManager: DataManager.testing,
                                   settingsStore: settingsStore,
-                                  payManager: PayManager(dataManager: DataManager.testing, settingsStore: settingsStore),
+                                  payManager: PayManager(dataManager: DataManager.testing,
+                                                         settingsStore: settingsStore,
+                                                         calendar: .current),
                                   notificationService: NotificationService(center: .current()),
                                   timerProvider: MockTimer.self)
         )
@@ -506,7 +508,9 @@ extension HomeViewModelModelTests {
         settingsStore.workTimeInSeconds = workTimerLimit
         sut = .init(HomeViewModel(dataManager: DataManager.testing,
                                   settingsStore: settingsStore,
-                                  payManager: PayManager(dataManager: DataManager.testing, settingsStore: settingsStore),
+                                  payManager: PayManager(dataManager: DataManager.testing, 
+                                                         settingsStore: settingsStore,
+                                                         calendar: .current),
                                   notificationService: NotificationService(center: .current()),
                                   timerProvider: MockTimer.self)
         )
@@ -519,7 +523,8 @@ extension HomeViewModelModelTests {
         sut = .init(dataManager: DataManager.testing,
                     settingsStore: settingsStore,
                     payManager: PayManager(dataManager: .testing, 
-                                           settingsStore: settingsStore),
+                                           settingsStore: settingsStore,
+                                           calendar: .current),
                     notificationService: NotificationService(center: .current()),
                     timerProvider: MockTimer.self)
     }

--- a/PunchPadTests/HomeViewModelTests.swift
+++ b/PunchPadTests/HomeViewModelTests.swift
@@ -23,6 +23,7 @@ final class HomeViewModelModelTests: XCTestCase {
         sut = .init(HomeViewModel(dataManager: DataManager.testing,
                                   settingsStore: settingsStore,
                                   payManager: PayManager(dataManager: DataManager.testing, settingsStore: settingsStore),
+                                  notificationService: NotificationService(center: .current()),
                                   timerProvider: MockTimer.self)
         )
     }
@@ -506,6 +507,7 @@ extension HomeViewModelModelTests {
         sut = .init(HomeViewModel(dataManager: DataManager.testing,
                                   settingsStore: settingsStore,
                                   payManager: PayManager(dataManager: DataManager.testing, settingsStore: settingsStore),
+                                  notificationService: NotificationService(center: .current()),
                                   timerProvider: MockTimer.self)
         )
     }
@@ -518,6 +520,7 @@ extension HomeViewModelModelTests {
                     settingsStore: settingsStore,
                     payManager: PayManager(dataManager: .testing, 
                                            settingsStore: settingsStore),
+                    notificationService: NotificationService(center: .current()),
                     timerProvider: MockTimer.self)
     }
     

--- a/PunchPadTests/PayManagerTests.swift
+++ b/PunchPadTests/PayManagerTests.swift
@@ -64,7 +64,7 @@ extension PayManagerTests {
         XCTAssertEqual(result.payUpToDate, expectedPayHour * 40)
     }
     
-    func testGeneratingDataForPastMonth() {
+    func testGenerateDataForPastMonth() {
         //Given
         guard let date = generateStableDate(),
               let testPeriod = try? periodService.generatePeriod(for: date, in: .month) else {
@@ -90,7 +90,28 @@ extension PayManagerTests {
     }
     
     func testGenerateDataForPastYear() {
-        
+        //Given
+        guard let date = generateStableDate(),
+              let testPeriod = try? periodService.generatePeriod(for: date, in: .year) else {
+            XCTFail("Failed to build date from given string")
+            return
+        }
+        let expectedNumberOfWorkingDays = addTestData(forPeriod: testPeriod,
+                                              workTimeInSec: 8 * 3600,
+                                              overtimeInSec: 0,
+                                              standardWorkTimeInSec: 8 * 3600,
+                                              maximumOvertimeInSec: 5 * 3600,
+                                              grossPayPerMonth: settingsStore.grossPayPerMonth
+        )
+        //When
+        sut.updatePeriod(with: testPeriod)
+        //Then
+        let result = sut.grossDataForPeriod
+        let expectedPayHour = Double(12 * settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDays * 8)
+        XCTAssertEqual(result.numberOfWorkingDays, expectedNumberOfWorkingDays)
+        XCTAssertEqual(result.payPerHour, expectedPayHour, accuracy: 0.01)
+        XCTAssertEqual(result.payUpToDate, Double(12 * settingsStore.grossPayPerMonth), accuracy: 0.01)
+        XCTAssertNil(result.payPredicted)
     }
 }
 

--- a/PunchPadTests/PayManagerTests.swift
+++ b/PunchPadTests/PayManagerTests.swift
@@ -259,6 +259,28 @@ extension PayManagerTests {
         XCTAssertNil(result.payPredicted)
         XCTAssertEqual(result.payUpToDate, expectedPayUpToDate)
     }
+    
+    func testGenerateDataForYearPeriodInFuture() {
+        //Given
+        let date = Calendar.current.startOfDay(for: Date())
+        guard let dateInFuture = Calendar.current.date(byAdding: .year, value: 1, to: date),
+              let period = try? periodService.generatePeriod(for: dateInFuture, in: .year) else {
+            XCTFail("FAILED TO PREPARE INPUT DATA")
+            return
+        }
+        let expectedNumberOfWorkingDays = numberOfWorkingDays(in: period)
+        let expectedPayPerHour = Double(12 * settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDays * 8)
+        let expectedPayUpToDate: Double = 0
+        //When
+        sut.updatePeriod(with: period)
+        //Then
+        let result = sut.grossDataForPeriod
+        XCTAssertEqual(result.payPerHour, expectedPayPerHour, accuracy: 0.01)
+        XCTAssertEqual(result.numberOfWorkingDays, expectedNumberOfWorkingDays)
+        XCTAssertNil(result.payPredicted)
+        XCTAssertEqual(result.payUpToDate, expectedPayUpToDate)
+    }
+    
 }
 
 

--- a/PunchPadTests/PayManagerTests.swift
+++ b/PunchPadTests/PayManagerTests.swift
@@ -22,7 +22,8 @@ final class PayManagerTests: XCTestCase {
         SettingsStore.setTestUserDefaults()
         settingsStore = SettingsStore()
         sut = .init(dataManager: dataManager,
-                    settingsStore: settingsStore)
+                    settingsStore: settingsStore,
+                    calendar: .current)
         periodService = ChartPeriodService(calendar: .current)
     }
     

--- a/PunchPadTests/PayManagerTests.swift
+++ b/PunchPadTests/PayManagerTests.swift
@@ -237,6 +237,28 @@ extension PayManagerTests {
         XCTAssertNil(result.payPredicted)
         XCTAssertEqual(result.payUpToDate, 0)
     }
+    
+    func testGenerateDataForMonthPeriodInFuture() {
+        //Given
+        let date = Calendar.current.startOfDay(for: Date())
+        guard let dateInFuture = Calendar.current.date(byAdding: .month, value: 1, to: date),
+              let numberOfWorkingDaysInMonth = numberOfWorkingDays(for: dateInFuture),
+              let period = try? periodService.generatePeriod(for: dateInFuture, in: .month) else {
+            XCTFail("FAILED TO PREPARE INPUT DATA")
+            return
+        }
+        let expectedPayPerHour = Double(settingsStore.grossPayPerMonth) / (Double(numberOfWorkingDaysInMonth) * 8)
+        let expectedNumberOfWorkingDays = numberOfWorkingDaysInMonth
+        let expectedPayUpToDate: Double = 0
+        //When
+        sut.updatePeriod(with: period)
+        //Then
+        let result = sut.grossDataForPeriod
+        XCTAssertEqual(result.payPerHour, expectedPayPerHour, accuracy: 0.01)
+        XCTAssertEqual(result.numberOfWorkingDays, expectedNumberOfWorkingDays)
+        XCTAssertNil(result.payPredicted)
+        XCTAssertEqual(result.payUpToDate, expectedPayUpToDate)
+    }
 }
 
 


### PR DESCRIPTION
This PR resolves issue #38. Former implementation was complicated and used a lot of different approaches to calculate the data based on where the period was compared to current time. This caused a number of bugs and issues with more obscure state of data and requests. To solve this issue more states were added to testing scenarios and more consistent way of generating salary data was introduced. 

In this PR additional testing was added to pay manager tests:
- tests for generating data in week, month and year period in past 
- tests for generating data in week, month and year periods that are still lasting (end date in future)
- tests for generating data in weeks, month and year periods situated fully in future (start date in future) 

Gross salary data was modified to: 
-Retrieve existing data 
-Generate array of "perfect" data - containing existing data where present 
- based on array of perfect data calculate all of the parameters 

This results in much more robust implementation and less potential for bugs.  