### PR TITLE
48 implement displaying all data in statistics view

### DIFF
--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		D66A4DF62B7AA72800D16110 /* ChartType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DF52B7AA72800D16110 /* ChartType.swift */; };
 		D66A4DF82B7AA74F00D16110 /* Period.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DF72B7AA74F00D16110 /* Period.swift */; };
 		D66A4DFA2B7AD3B000D16110 /* XCTestCase+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DF92B7AD3B000D16110 /* XCTestCase+Extension.swift */; };
+		D66A4E002B7AD46100D16110 /* Published+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DFF2B7AD46100D16110 /* Published+Extension.swift */; };
 		D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */; };
 		D67332E72AADB8B1005FFE7F /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */; };
 		D67332EA2AAE3D3D005FFE7F /* StatisticsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */; };
@@ -190,6 +191,7 @@
 		D66A4DF52B7AA72800D16110 /* ChartType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartType.swift; sourceTree = "<group>"; };
 		D66A4DF72B7AA74F00D16110 /* Period.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Period.swift; sourceTree = "<group>"; };
 		D66A4DF92B7AD3B000D16110 /* XCTestCase+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extension.swift"; sourceTree = "<group>"; };
+		D66A4DFF2B7AD46100D16110 /* Published+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Published+Extension.swift"; sourceTree = "<group>"; };
 		D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgument.swift; sourceTree = "<group>"; };
 		D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsUITests.swift; sourceTree = "<group>"; };
 		D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModelTests.swift; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				D66A4DF92B7AD3B000D16110 /* XCTestCase+Extension.swift */,
+				D66A4DFF2B7AD46100D16110 /* Published+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -754,6 +757,7 @@
 				D6C458A529D229230069D89B /* ClockInTests.swift in Sources */,
 				D6CBB8662B3443360074CE8B /* EditSheetViewModelTests.swift in Sources */,
 				D6799EFC29E1BC0F0080E32A /* HistoryViewModelTests.swift in Sources */,
+				D66A4E002B7AD46100D16110 /* Published+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		D66750EC29D71C8300757F17 /* HistoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66750EB29D71C8300757F17 /* HistoryRow.swift */; };
 		D66A4DF62B7AA72800D16110 /* ChartType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DF52B7AA72800D16110 /* ChartType.swift */; };
 		D66A4DF82B7AA74F00D16110 /* Period.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DF72B7AA74F00D16110 /* Period.swift */; };
+		D66A4DFA2B7AD3B000D16110 /* XCTestCase+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DF92B7AD3B000D16110 /* XCTestCase+Extension.swift */; };
 		D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */; };
 		D67332E72AADB8B1005FFE7F /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */; };
 		D67332EA2AAE3D3D005FFE7F /* StatisticsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */; };
@@ -188,6 +189,7 @@
 		D66750EB29D71C8300757F17 /* HistoryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryRow.swift; sourceTree = "<group>"; };
 		D66A4DF52B7AA72800D16110 /* ChartType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartType.swift; sourceTree = "<group>"; };
 		D66A4DF72B7AA74F00D16110 /* Period.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Period.swift; sourceTree = "<group>"; };
+		D66A4DF92B7AD3B000D16110 /* XCTestCase+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extension.swift"; sourceTree = "<group>"; };
 		D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgument.swift; sourceTree = "<group>"; };
 		D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsUITests.swift; sourceTree = "<group>"; };
 		D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModelTests.swift; sourceTree = "<group>"; };
@@ -318,6 +320,14 @@
 			path = Style;
 			sourceTree = "<group>";
 		};
+		D66A4DFB2B7AD3C900D16110 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				D66A4DF92B7AD3B000D16110 /* XCTestCase+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		D67332E82AAE3C1A005FFE7F /* ScreenHelpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -418,6 +428,7 @@
 			isa = PBXGroup;
 			children = (
 				D61945EB29E7306B0046DE1F /* HomeViewModelTests.swift */,
+				D66A4DFB2B7AD3C900D16110 /* Extensions */,
 				D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */,
 				D629CEFA2B363B500036579D /* TimerServiceTests.swift */,
 				D65A976A29F2E6B800462D8C /* StatisticsViewModelTests.swift */,
@@ -737,6 +748,7 @@
 				D65A976B29F2E6B800462D8C /* StatisticsViewModelTests.swift in Sources */,
 				D61945EC29E7306B0046DE1F /* HomeViewModelTests.swift in Sources */,
 				D60480D82B122CDA00D6D70D /* ChartPeriodServiceTests.swift in Sources */,
+				D66A4DFA2B7AD3B000D16110 /* XCTestCase+Extension.swift in Sources */,
 				D629CEFB2B363B500036579D /* TimerServiceTests.swift in Sources */,
 				D61945F029E735D80046DE1F /* MockTimer.swift in Sources */,
 				D6C458A529D229230069D89B /* ClockInTests.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		D666ADCC2AC05A0500B74663 /* CaseIterable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D666ADCB2AC05A0500B74663 /* CaseIterable+Extension.swift */; };
 		D66750EA29D713C900757F17 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66750E929D713C900757F17 /* HistoryView.swift */; };
 		D66750EC29D71C8300757F17 /* HistoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66750EB29D71C8300757F17 /* HistoryRow.swift */; };
+		D66A4DF62B7AA72800D16110 /* ChartType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DF52B7AA72800D16110 /* ChartType.swift */; };
+		D66A4DF82B7AA74F00D16110 /* Period.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A4DF72B7AA74F00D16110 /* Period.swift */; };
 		D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */; };
 		D67332E72AADB8B1005FFE7F /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */; };
 		D67332EA2AAE3D3D005FFE7F /* StatisticsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */; };
@@ -184,6 +186,8 @@
 		D666ADCB2AC05A0500B74663 /* CaseIterable+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+Extension.swift"; sourceTree = "<group>"; };
 		D66750E929D713C900757F17 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		D66750EB29D71C8300757F17 /* HistoryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryRow.swift; sourceTree = "<group>"; };
+		D66A4DF52B7AA72800D16110 /* ChartType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartType.swift; sourceTree = "<group>"; };
+		D66A4DF72B7AA74F00D16110 /* Period.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Period.swift; sourceTree = "<group>"; };
 		D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgument.swift; sourceTree = "<group>"; };
 		D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsUITests.swift; sourceTree = "<group>"; };
 		D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModelTests.swift; sourceTree = "<group>"; };
@@ -511,6 +515,8 @@
 				D6CA773E2B40BB4D00C98AF3 /* Route.swift */,
 				D698F3EF2B5C131D00D9DFF4 /* NotificationService.swift */,
 				D698F3F12B5C1F8600D9DFF4 /* AppNotification.swift */,
+				D66A4DF52B7AA72800D16110 /* ChartType.swift */,
+				D66A4DF72B7AA74F00D16110 /* Period.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -653,6 +659,7 @@
 				D64574B629D9F37400207168 /* Entry.swift in Sources */,
 				D6E6832E2B79502B009C6CEC /* ChartableEntry.swift in Sources */,
 				D6C458C729D36C050069D89B /* RingView.swift in Sources */,
+				D66A4DF62B7AA72800D16110 /* ChartType.swift in Sources */,
 				D6CBB8682B34ACF20074CE8B /* Calendar+Extension.swift in Sources */,
 				D6EA695E2AF8498D00D8F6C3 /* OnboardingOvertimeView.swift in Sources */,
 				D682AF922B3C77F5004EE208 /* ChartTimeRange.swift in Sources */,
@@ -687,6 +694,7 @@
 				D60480DA2B122D3F00D6D70D /* ChartPeriodService.swift in Sources */,
 				D66750EA29D713C900757F17 /* HistoryView.swift in Sources */,
 				D64313B82B1E606B003B5DBC /* PreviewDataFactory.swift in Sources */,
+				D66A4DF82B7AA74F00D16110 /* Period.swift in Sources */,
 				D617D43D2B4987480069AA3B /* GrossSalary.swift in Sources */,
 				D6C458C129D2DD4F0069D89B /* HomeViewModel.swift in Sources */,
 				D6C4589629D229210069D89B /* ContentView.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -50,7 +50,7 @@
 		D67332EA2AAE3D3D005FFE7F /* StatisticsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */; };
 		D6799EFC29E1BC0F0080E32A /* HistoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */; };
 		D682AF922B3C77F5004EE208 /* ChartTimeRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = D682AF912B3C77F5004EE208 /* ChartTimeRange.swift */; };
-		D682AF942B3D83A2004EE208 /* MonthEntrySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D682AF932B3D83A2004EE208 /* MonthEntrySummary.swift */; };
+		D682AF942B3D83A2004EE208 /* EntrySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D682AF932B3D83A2004EE208 /* EntrySummary.swift */; };
 		D68384F929DB25DD00228491 /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68384F829DB25DD00228491 /* SettingViewModel.swift */; };
 		D6842EC029EC178000731E84 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6842EBF29EC178000731E84 /* StatisticsView.swift */; };
 		D6842EC229EC179200731E84 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6842EC129EC179200731E84 /* StatisticsViewModel.swift */; };
@@ -188,7 +188,7 @@
 		D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModelTests.swift; sourceTree = "<group>"; };
 		D6801A142B404F61003F54F9 /* NavigationKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NavigationKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D682AF912B3C77F5004EE208 /* ChartTimeRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartTimeRange.swift; sourceTree = "<group>"; };
-		D682AF932B3D83A2004EE208 /* MonthEntrySummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthEntrySummary.swift; sourceTree = "<group>"; };
+		D682AF932B3D83A2004EE208 /* EntrySummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntrySummary.swift; sourceTree = "<group>"; };
 		D68384F829DB25DD00228491 /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
 		D6842EBF29EC178000731E84 /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
 		D6842EC129EC179200731E84 /* StatisticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewModel.swift; sourceTree = "<group>"; };
@@ -497,7 +497,7 @@
 				D65FD53C29D8B259006CC34F /* PersistanceController.swift */,
 				D64574AF29D9E6A000207168 /* DataManager.swift */,
 				D64574B529D9F37400207168 /* Entry.swift */,
-				D682AF932B3D83A2004EE208 /* MonthEntrySummary.swift */,
+				D682AF932B3D83A2004EE208 /* EntrySummary.swift */,
 				D6842EC329EC62DD00731E84 /* PayManager.swift */,
 				D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */,
 				D60EB9B52AB0D7000053136A /* Container.swift */,
@@ -670,7 +670,7 @@
 				D64574B329D9F16900207168 /* EntryMO+CoreDataClass.swift in Sources */,
 				D64574B429D9F16900207168 /* EntryMO+CoreDataProperties.swift in Sources */,
 				D653FEEC2B320E1600ECFCF2 /* TimeIntervalPicker.swift in Sources */,
-				D682AF942B3D83A2004EE208 /* MonthEntrySummary.swift in Sources */,
+				D682AF942B3D83A2004EE208 /* EntrySummary.swift in Sources */,
 				D621C0CA2B3B79850065DF8C /* CircleButton.swift in Sources */,
 				D6D906AE2AA0BEDE004E09C9 /* ScreenIdentifier.swift in Sources */,
 				D61F11342AB3A6FF00902D6D /* ColorScheme+Extension.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		D6D906B12AA12BDB004E09C9 /* BackgroundFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906B02AA12BDB004E09C9 /* BackgroundFactory.swift */; };
 		D6E2C15929D6C20E00229286 /* WorkHistory.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = D6E2C15729D6C20E00229286 /* WorkHistory.xcdatamodeld */; };
 		D6E2C15B29D6C31800229286 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E2C15A29D6C31800229286 /* HistoryViewModel.swift */; };
+		D6E6832E2B79502B009C6CEC /* ChartableEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E6832D2B79502B009C6CEC /* ChartableEntry.swift */; };
 		D6E6B8732AF98A4B0073D911 /* OnboardingNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E6B8722AF98A4B0073D911 /* OnboardingNotificationView.swift */; };
 		D6E6B8752AF98EB40073D911 /* OnboardingSalaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E6B8742AF98EB40073D911 /* OnboardingSalaryView.swift */; };
 		D6E6B8772AF992F90073D911 /* OnboardingFinishView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E6B8762AF992F90073D911 /* OnboardingFinishView.swift */; };
@@ -235,6 +236,7 @@
 		D6D906B02AA12BDB004E09C9 /* BackgroundFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFactory.swift; sourceTree = "<group>"; };
 		D6E2C15829D6C20E00229286 /* WorkHistory.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = WorkHistory.xcdatamodel; sourceTree = "<group>"; };
 		D6E2C15A29D6C31800229286 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModel.swift; sourceTree = "<group>"; };
+		D6E6832D2B79502B009C6CEC /* ChartableEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartableEntry.swift; sourceTree = "<group>"; };
 		D6E6B8722AF98A4B0073D911 /* OnboardingNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNotificationView.swift; sourceTree = "<group>"; };
 		D6E6B8742AF98EB40073D911 /* OnboardingSalaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSalaryView.swift; sourceTree = "<group>"; };
 		D6E6B8762AF992F90073D911 /* OnboardingFinishView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFinishView.swift; sourceTree = "<group>"; };
@@ -497,6 +499,7 @@
 				D65FD53C29D8B259006CC34F /* PersistanceController.swift */,
 				D64574AF29D9E6A000207168 /* DataManager.swift */,
 				D64574B529D9F37400207168 /* Entry.swift */,
+				D6E6832D2B79502B009C6CEC /* ChartableEntry.swift */,
 				D682AF932B3D83A2004EE208 /* EntrySummary.swift */,
 				D6842EC329EC62DD00731E84 /* PayManager.swift */,
 				D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */,
@@ -648,6 +651,7 @@
 				D6842EC429EC62DE00731E84 /* PayManager.swift in Sources */,
 				D64766C52AFEBD9D0013AC9A /* ChartLegendView.swift in Sources */,
 				D64574B629D9F37400207168 /* Entry.swift in Sources */,
+				D6E6832E2B79502B009C6CEC /* ChartableEntry.swift in Sources */,
 				D6C458C729D36C050069D89B /* RingView.swift in Sources */,
 				D6CBB8682B34ACF20074CE8B /* Calendar+Extension.swift in Sources */,
 				D6EA695E2AF8498D00D8F6C3 /* OnboardingOvertimeView.swift in Sources */,

--- a/PunchPad/ChartPeriodService.swift
+++ b/PunchPad/ChartPeriodService.swift
@@ -49,6 +49,15 @@ class ChartPeriodService {
         return (startDate, finishDate)
     }
     
+    func generatePeriod(from startEntry: Entry, to finishEntry: Entry) throws -> Period {
+        let startDate = calendar.startOfDay(for: startEntry.startDate)
+        let startOfFinishEntryDay = calendar.startOfDay(for: finishEntry.finishDate)
+        guard let finishDate = calendar.date(byAdding: .day, value: 1, to: startOfFinishEntryDay) else {
+            throw ChartPeriodServiceError.failedToCreateDateByAddingComponents
+        }
+        return (startDate, finishDate)
+    }
+    
     func retardPeriod(by timeRange: ChartTimeRange, from currentPeriod: Period) throws -> Period {
         guard let dateInPreviousPeriod = calendar.date(byAdding: .day, value: -1, to: currentPeriod.0) else {
             throw ChartPeriodServiceError.failedToCreateDateByAddingComponents

--- a/PunchPad/Factory/ChartFactory.swift
+++ b/PunchPad/Factory/ChartFactory.swift
@@ -98,7 +98,46 @@ struct ChartFactory {
             }
         }
     }
-    
+    @ViewBuilder
+    static func buildBarChartForWeeks(data: [EntrySummary], firstColor: Color, secondColor: Color, axisColor: Color) -> some View {
+        Chart(data) { summary in
+            BarMark(x: .value("Date", summary.startDate, unit: .weekOfYear),
+                    y: .value("Hours worked", summary.workTimeInSeconds / 3600)
+            )
+            .foregroundStyle(firstColor)
+            
+            BarMark(x: .value("Date", summary.startDate, unit: .weekOfYear),
+                    y: .value("Hours overtime", summary.overtimeInSecond / 3600)
+            )
+            .foregroundStyle(secondColor)
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic) { value in
+                AxisGridLine()
+                    .foregroundStyle(axisColor)
+                
+                AxisValueLabel() {
+                    if let date = value.as(Date.self) {
+                        Text(FormatterFactory.makeMonthDateFormatter().string(from: date))
+                            .foregroundStyle(axisColor)
+                    }
+                }
+            }
+        }
+        .chartYAxis {
+            AxisMarks(values: .automatic) { value in
+                AxisGridLine()
+                    .foregroundStyle(axisColor)
+                
+                AxisValueLabel() {
+                    if let intVal = value.as(Int.self) {
+                        Text("\(intVal)")
+                            .foregroundStyle(axisColor)
+                    }
+                }
+            }
+        }
+    }
     @ViewBuilder
     static func buildChartLegend() -> some View {
         ChartLegendView(chartLegendItems: [

--- a/PunchPad/Factory/ChartFactory.swift
+++ b/PunchPad/Factory/ChartFactory.swift
@@ -7,25 +7,69 @@
 
 import SwiftUI
 import Charts
+import ThemeKit
 
 struct ChartFactory {
-    // TODO: ADD FLEXIBILITY WITH KEY PATHS
-    @ViewBuilder
-    static func buildBarChart(entries: [Entry], firstColor: Color, secondColor: Color, axisColor: Color, includeRuleMark: Bool = false) -> some View {
-            Chart(entries) {
-                // ruler
-                if includeRuleMark {
-                    RuleMark(y: .value("WorkGoal", 8))
-                        .lineStyle(.init(dash: [10]))
-                        .foregroundStyle(.red)
-                }
-                
+    /// Build chart using buildBarChart function with default colors from theme kit, x axis unis set to day and x axis value labels formatter to 2 digit days and 3 letter description of month (such as `21 Jun`)
+    /// - Parameter data: array of chartableEntry data
+    /// - Returns: Chart view
+    @ViewBuilder static func buildBarChartForDays<T: ChartableEntry>(data: [T]) -> some View {
+        buildBarChartWithDefaultColors(data: data,
+                                       xUnit: .day,
+                                       xFormatter: FormatterFactory.makeDayAndMonthDateFormatter(),
+                                       yScale: 0...15)
+    }
+    
+    /// Build chart using buildBarChart function with default colors from theme kit, x axis unis set to week of year and x axis value labels formatter to 2 digit days and 3 letter description of month (such as `21 Jun`)
+    /// - Parameter data: array of chartableEntry data
+    /// - Returns: Chart view
+    @ViewBuilder static func buildBarChartForWeeks<T: ChartableEntry>(data: [T]) -> some View {
+        buildBarChartWithDefaultColors(data: data,
+                                       xUnit: .weekOfYear,
+                                       xFormatter: FormatterFactory.makeDayAndMonthDateFormatter(),
+                                       yScale: nil)
+    }
+    
+    
+    /// Build chart using buildBarChart function with default colors from theme kit, x axis unis set to month and x axis value labels formatter to 3 letter description of month (such as `Jun`)
+    /// - Parameter data: array of chartableEntry data
+    /// - Returns: Chart view
+    @ViewBuilder static func buildBarChartForMonths<T: ChartableEntry>(data: [T]) -> some View {
+        buildBarChartWithDefaultColors(data: data,
+                                       xUnit: .month,
+                                       xFormatter: FormatterFactory.makeMonthDateFormatter(),
+                                       yScale: nil)
+    }
+    
+    /// Build chart using buildBarChart function with default colors defined in ThemeKit
+    /// - Parameters:
+    ///   - data: array of chartableEntry data to be displayed
+    ///   - xUnit: Calendar component unit to be used for x axis
+    ///   - xFormatter: formatter used for x axis values of data
+    ///   - yScale: optional scale to be used on y axis
+    /// - Returns: Chart view
+    @ViewBuilder static func buildBarChartWithDefaultColors<T: ChartableEntry>(data: [T], xUnit: Calendar.Component, xFormatter: DateFormatter, yScale: ClosedRange<Int>? = nil) -> some View {
+        buildBarChart(data: data, firstColor: .theme.primary, secondColor: .theme.redChart, axisColor: .theme.buttonColor, xUnit: xUnit, xFormatter: xFormatter, yScale: yScale)
+    }
+    
+    /// Build BarChart based on chartable entry array
+    /// - Parameters:
+    ///   - data: array of data to be displayed
+    ///   - firstColor: color of bar representing worktime
+    ///   - secondColor: color of bar representing overtime
+    ///   - axisColor: color of axis features - marks, gridlines, labels
+    ///   - xUnit: Calendar component unit to be used for x axis
+    ///   - xFormatter: formatter used for x axis values of data
+    ///   - yScale: optional scale to be used on y axis
+    /// - Returns: Chart View
+    @ViewBuilder static func buildBarChart<T: ChartableEntry>(data: [T], firstColor: Color, secondColor: Color, axisColor: Color, xUnit: Calendar.Component, xFormatter: DateFormatter, yScale: ClosedRange<Int>? = nil) -> some View {
+            Chart(data) {
                 BarMark(
-                    x: .value("Date", $0.startDate, unit: .day),
+                    x: .value("Date", $0.startDate, unit: xUnit),
                     y: .value("Hours worked", $0.workTimeInSeconds / 3600))
                 .foregroundStyle(firstColor)
                 
-                BarMark(x: .value("Date", $0.startDate,unit: .day),
+                BarMark(x: .value("Date", $0.startDate,unit: xUnit),
                         y: .value("Hours worked", $0.overTimeInSeconds / 3600))
                 .foregroundStyle(secondColor)
             }
@@ -36,7 +80,7 @@ struct ChartFactory {
                     
                     AxisValueLabel() {
                         if let date = value.as(Date.self) {
-                            Text(FormatterFactory.makeDayAndMonthDateFormatter().string(from: date))
+                            Text(xFormatter.string(from: date))
                                 .foregroundStyle(axisColor)
                         }
                     }
@@ -55,99 +99,28 @@ struct ChartFactory {
                     }
                 }
             }
-            .chartYScale(domain: 0...15)
+            .ifLet(yScale, transform: { chart, domain in
+                chart.chartYScale(domain: domain)
+            })
     }
     
-    @ViewBuilder
-    static func buildBarChartForYear(data: [EntrySummary], firstColor: Color, secondColor: Color, axisColor: Color) -> some View {
-        Chart(data) { summary in
-            BarMark(x: .value("Date", summary.startDate, unit: .month),
-                    y: .value("Hours worked", summary.workTimeInSeconds / 3600)
-            )
-            .foregroundStyle(firstColor)
-            
-            BarMark(x: .value("Date", summary.startDate, unit: .month),
-                    y: .value("Hours overtime", summary.overtimeInSecond / 3600)
-            )
-            .foregroundStyle(secondColor)
-        }
-        .chartXAxis {
-            AxisMarks(values: .automatic) { value in
-                AxisGridLine()
-                    .foregroundStyle(axisColor)
-                
-                AxisValueLabel() {
-                    if let date = value.as(Date.self) {
-                        Text(FormatterFactory.makeMonthDateFormatter().string(from: date))
-                            .foregroundStyle(axisColor)
-                    }
-                }
-            }
-        }
-        .chartYAxis {
-            AxisMarks(values: .automatic) { value in
-                AxisGridLine()
-                    .foregroundStyle(axisColor)
-                
-                AxisValueLabel() {
-                    if let intVal = value.as(Int.self) {
-                        Text("\(intVal)")
-                            .foregroundStyle(axisColor)
-                    }
-                }
-            }
-        }
-    }
-    @ViewBuilder
-    static func buildBarChartForWeeks(data: [EntrySummary], firstColor: Color, secondColor: Color, axisColor: Color) -> some View {
-        Chart(data) { summary in
-            BarMark(x: .value("Date", summary.startDate, unit: .weekOfYear),
-                    y: .value("Hours worked", summary.workTimeInSeconds / 3600)
-            )
-            .foregroundStyle(firstColor)
-            
-            BarMark(x: .value("Date", summary.startDate, unit: .weekOfYear),
-                    y: .value("Hours overtime", summary.overtimeInSecond / 3600)
-            )
-            .foregroundStyle(secondColor)
-        }
-        .chartXAxis {
-            AxisMarks(values: .automatic) { value in
-                AxisGridLine()
-                    .foregroundStyle(axisColor)
-                
-                AxisValueLabel() {
-                    if let date = value.as(Date.self) {
-                        Text(FormatterFactory.makeMonthDateFormatter().string(from: date))
-                            .foregroundStyle(axisColor)
-                    }
-                }
-            }
-        }
-        .chartYAxis {
-            AxisMarks(values: .automatic) { value in
-                AxisGridLine()
-                    .foregroundStyle(axisColor)
-                
-                AxisValueLabel() {
-                    if let intVal = value.as(Int.self) {
-                        Text("\(intVal)")
-                            .foregroundStyle(axisColor)
-                    }
-                }
-            }
-        }
-    }
-    @ViewBuilder
-    static func buildChartLegend() -> some View {
+    /// Build chart legend view for hours worked and overtime
+    /// - Returns: ChartLegendView
+    @ViewBuilder static func buildChartLegend() -> some View {
         ChartLegendView(chartLegendItems: [
             ChartLegendItem(itemName: "Hours worked", itemShape: Rectangle(), itemShapeColor: .blue),
             ChartLegendItem(itemName: "Overtime", itemShape: Circle(), itemShapeColor: .green)])
         .font(.caption)
     }
     
-    @ViewBuilder
-    static func buildPointChartForPunchTime(entries: [Entry], property: KeyPath<Entry, Date>, color: Color, displayName: String) -> some View {
+    /// Build Chart view with point mark data for entry array hour porperty
+    /// - Parameters:
+    ///   - entries: entry array to be displayed on chart
+    ///   - property: keyPath to property from which to display hour from
+    ///   - color: color of point marker
+    ///   - displayName: display name to show on legend
+    /// - Returns: Chart with point markers
+    @ViewBuilder static func buildPointChartForPunchTime(entries: [Entry], property: KeyPath<Entry, Date>, color: Color, displayName: String) -> some View {
         Chart(entries) {
             PointMark(
                 x: .value("Date", $0.startDate),

--- a/PunchPad/Factory/ChartFactory.swift
+++ b/PunchPad/Factory/ChartFactory.swift
@@ -59,7 +59,7 @@ struct ChartFactory {
     }
     
     @ViewBuilder
-    static func buildBarChartForYear(data: [MonthEntrySummary], firstColor: Color, secondColor: Color, axisColor: Color) -> some View {
+    static func buildBarChartForYear(data: [EntrySummary], firstColor: Color, secondColor: Color, axisColor: Color) -> some View {
         Chart(data) { summary in
             BarMark(x: .value("Date", summary.startDate, unit: .month),
                     y: .value("Hours worked", summary.workTimeInSeconds / 3600)

--- a/PunchPad/Model/ChartType.swift
+++ b/PunchPad/Model/ChartType.swift
@@ -1,0 +1,12 @@
+//
+//  ChartType.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 12/02/2024.
+//
+
+import Foundation
+
+enum ChartType {
+    case time, startTime, finishTime
+}

--- a/PunchPad/Model/ChartableEntry.swift
+++ b/PunchPad/Model/ChartableEntry.swift
@@ -1,0 +1,15 @@
+//
+//  ChartableEntry.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 11/02/2024.
+//
+
+import Foundation
+
+protocol ChartableEntry: Identifiable, Hashable {
+    var id: UUID { get }
+    var startDate: Date { get }
+    var workTimeInSeconds: Int { get }
+    var overTimeInSeconds: Int { get }
+}

--- a/PunchPad/Model/Entry.swift
+++ b/PunchPad/Model/Entry.swift
@@ -9,7 +9,7 @@ import Foundation
 
 //front facing struct that seperates views from the coreData objects 
 
-struct Entry: Identifiable, Hashable {
+struct Entry: ChartableEntry {
     var id: UUID
     var startDate: Date
     var finishDate: Date

--- a/PunchPad/Model/EntrySummary.swift
+++ b/PunchPad/Model/EntrySummary.swift
@@ -7,23 +7,25 @@
 
 import Foundation
 
-struct EntrySummary: Identifiable, Hashable {
+struct EntrySummary: ChartableEntry {
+    
+    
     let id: UUID
     let startDate: Date
     let workTimeInSeconds: Int
-    let overtimeInSecond: Int
+    let overTimeInSeconds: Int
     
-    init(startDate: Date, workTimeInSeconds: Int, overtimeInSecond: Int) {
+    init(startDate: Date, workTimeInSeconds: Int, overTimeInSeconds: Int) {
         self.id = UUID()
         self.startDate = startDate
         self.workTimeInSeconds = workTimeInSeconds
-        self.overtimeInSecond = overtimeInSecond
+        self.overTimeInSeconds = overTimeInSeconds
     }
     
     init(fromEntries array: [Entry]) {
         let startDate = array.first?.startDate ?? Date()
         let workTimeSum = array.map({ $0.workTimeInSeconds }).reduce(0, +)
         let overtimeSum = array.map({ $0.overTimeInSeconds }).reduce(0, +)
-        self.init(startDate: startDate, workTimeInSeconds: workTimeSum, overtimeInSecond: overtimeSum)
+        self.init(startDate: startDate, workTimeInSeconds: workTimeSum, overTimeInSeconds: overtimeSum)
     }
 }

--- a/PunchPad/Model/EntrySummary.swift
+++ b/PunchPad/Model/EntrySummary.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MonthEntrySummary: Identifiable, Hashable {
+struct EntrySummary: Identifiable, Hashable {
     let id: UUID
     let startDate: Date
     let workTimeInSeconds: Int

--- a/PunchPad/Model/Period.swift
+++ b/PunchPad/Model/Period.swift
@@ -1,0 +1,10 @@
+//
+//  Period.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 12/02/2024.
+//
+
+import Foundation
+
+typealias Period = (Date, Date)

--- a/PunchPad/View/MainView.swift
+++ b/PunchPad/View/MainView.swift
@@ -48,7 +48,8 @@ struct MainView: View {
         self._statViewModel = .init(wrappedValue:
                                         StatisticsViewModel(dataManager: container.dataManager,
                                                             payManager: container.payManager,
-                                                            settingsStore: container.settingsStore)
+                                                            settingsStore: container.settingsStore,
+                                                            calendar: .current)
         )
         self._historyViewModel = .init(wrappedValue:
                                         HistoryViewModel(dataManager: container.dataManager,

--- a/PunchPad/View/StatisticsView.swift
+++ b/PunchPad/View/StatisticsView.swift
@@ -138,15 +138,27 @@ extension StatisticsView {
                                        secondColor: .theme.redChart,
                                        axisColor: .theme.buttonLabelGray
             )
-        case .year, .all:
+        case .year:
             ChartFactory.buildBarChartForYear(
                 data: viewModel.createMonthlySummary(entries: viewModel.entriesForChart),
                 firstColor: .theme.primary,
                 secondColor: .theme.redChart,
                 axisColor: .theme.buttonLabelGray
             )
+        case .all:
+            buildChartForAllData()
         }
     } // END OF VAR
+    
+    @ViewBuilder
+    private func buildChartForAllData() -> some View {
+        ChartFactory.buildBarChartForWeeks(
+            data: viewModel.createSummaryForAll(entries: viewModel.entriesForChart),
+            firstColor: .theme.primary,
+            secondColor: .theme.redChart,
+            axisColor: .theme.buttonLabelGray
+        )
+    }
     
     private func makePeriodRangeString(for period: Period, selectedRange: ChartTimeRange) -> String {
         switch selectedRange {

--- a/PunchPad/View/StatisticsView.swift
+++ b/PunchPad/View/StatisticsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Charts
+import ThemeKit
 
 struct StatisticsView: View {
     private typealias Identifier = ScreenIdentifier.StatisticsView
@@ -133,32 +134,17 @@ extension StatisticsView {
     var chart: some View {
         switch viewModel.chartTimeRange {
         case .week, .month:
-            ChartFactory.buildBarChart(entries: viewModel.entriesForChart,
-                                       firstColor: .theme.primary,
-                                       secondColor: .theme.redChart,
-                                       axisColor: .theme.buttonLabelGray
-            )
+            ChartFactory.buildBarChartForDays(data: viewModel.entryInPeriod)
         case .year:
-            ChartFactory.buildBarChartForYear(
-                data: viewModel.createMonthlySummary(entries: viewModel.entriesForChart),
-                firstColor: .theme.primary,
-                secondColor: .theme.redChart,
-                axisColor: .theme.buttonLabelGray
-            )
+            ChartFactory.buildBarChartForMonths(data: viewModel.entrySummaryByMonthYear)
         case .all:
-            buildChartForAllData()
+            if let groupedByWeek = viewModel.entriesSummaryByWeekYear {
+                ChartFactory.buildBarChartForWeeks(data: groupedByWeek)
+            } else {
+                ChartFactory.buildBarChartForMonths(data: viewModel.entrySummaryByMonthYear)
+            }
         }
     } // END OF VAR
-    
-    @ViewBuilder
-    private func buildChartForAllData() -> some View {
-        ChartFactory.buildBarChartForWeeks(
-            data: viewModel.createSummaryForAll(entries: viewModel.entriesForChart),
-            firstColor: .theme.primary,
-            secondColor: .theme.redChart,
-            axisColor: .theme.buttonLabelGray
-        )
-    }
     
     private func makePeriodRangeString(for period: Period, selectedRange: ChartTimeRange) -> String {
         switch selectedRange {
@@ -286,7 +272,9 @@ extension StatisticsView {
                             StatisticsViewModel(
                                 dataManager: container.dataManager,
                                 payManager: container.payManager,
-                                settingsStore: container.settingsStore)
+                                settingsStore: container.settingsStore,
+                                calendar: .current
+                            )
             )
             .environmentObject(container)
         }

--- a/PunchPad/View/StatisticsView.swift
+++ b/PunchPad/View/StatisticsView.swift
@@ -138,7 +138,7 @@ extension StatisticsView {
         case .year:
             ChartFactory.buildBarChartForMonths(data: viewModel.entrySummaryByMonthYear)
         case .all:
-            if let groupedByWeek = viewModel.entriesSummaryByWeekYear {
+            if let groupedByWeek = viewModel.entrySummaryByWeekYear {
                 ChartFactory.buildBarChartForWeeks(data: groupedByWeek)
             } else {
                 ChartFactory.buildBarChartForMonths(data: viewModel.entrySummaryByMonthYear)

--- a/PunchPad/ViewModel/EditShetViewModel.swift
+++ b/PunchPad/ViewModel/EditShetViewModel.swift
@@ -29,6 +29,7 @@ final class EditSheetViewModel: ObservableObject {
         TimeInterval(workTimeInSeconds + overTimeInSeconds)
     }
     var breakTime: TimeInterval {
+        guard startDate < finishDate else { return 0 }
         let timeFromDates = DateInterval(start: startDate, end: finishDate).duration
         if timeFromDates > workTimeInSeconds + overTimeInSeconds {
             return timeFromDates - workTimeInSeconds - overTimeInSeconds

--- a/PunchPad/ViewModel/StatisticsViewModel.swift
+++ b/PunchPad/ViewModel/StatisticsViewModel.swift
@@ -175,6 +175,7 @@ class StatisticsViewModel: ObservableObject {
 extension StatisticsViewModel {
     
     func loadPreviousPeriod() {
+        guard self.chartTimeRange != .all else { return }
         do {
             periodDisplayed = try chartPeriodService.retardPeriod(by: chartTimeRange, from: periodDisplayed)
             payManager.updatePeriod(with: periodDisplayed)
@@ -184,6 +185,7 @@ extension StatisticsViewModel {
     }
     
     func loadNextPeriod() {
+        guard self.chartTimeRange != .all else { return }
         do {
             periodDisplayed = try chartPeriodService.advancePeriod(by: chartTimeRange, from: periodDisplayed)
             payManager.updatePeriod(with: periodDisplayed)

--- a/PunchPad/ViewModel/StatisticsViewModel.swift
+++ b/PunchPad/ViewModel/StatisticsViewModel.swift
@@ -169,6 +169,28 @@ class StatisticsViewModel: ObservableObject {
         }
         return result
     }
+    
+    private func groupEntriesByYearWeek(_ entries: [Entry]) -> [[Entry]] {
+        var result = [[Entry]]()
+        var currentYearWeek: DateComponents?
+        var currentEntries: [Entry] = .init()
+        for entry in entries {
+            let entryDateComponents = Calendar.current.dateComponents([.weekOfYear, .yearForWeekOfYear], from: entry.startDate)
+            if entryDateComponents != currentYearWeek {
+                if !currentEntries.isEmpty {
+                    result.append(currentEntries)
+                }
+                currentEntries = [entry]
+                currentYearWeek = entryDateComponents
+            } else {
+                currentEntries.append(entry)
+            }
+        }
+        if !currentEntries.isEmpty {
+            result.append(currentEntries)
+        }
+        return result
+    }
 }
 
 //MARK: CHART DATA FUNCTIONS

--- a/PunchPad/ViewModel/StatisticsViewModel.swift
+++ b/PunchPad/ViewModel/StatisticsViewModel.swift
@@ -136,11 +136,11 @@ class StatisticsViewModel: ObservableObject {
         return result
     }
     
-    func createMonthlySummary(entries: [Entry]) -> [MonthEntrySummary] {
+    func createMonthlySummary(entries: [Entry]) -> [EntrySummary] {
         let groupedEntries = groupEntriesByYearMonth(entries)
-        var result = [MonthEntrySummary]()
+        var result = [EntrySummary]()
         for group in groupedEntries {
-            let summary = MonthEntrySummary(fromEntries: group)
+            let summary = EntrySummary(fromEntries: group)
             result.append(summary)
         }
         return result

--- a/PunchPad/ViewModel/StatisticsViewModel.swift
+++ b/PunchPad/ViewModel/StatisticsViewModel.swift
@@ -41,11 +41,11 @@ class StatisticsViewModel: ObservableObject {
         groupEntriesByYearMonth(entryInPeriod).map { EntrySummary(fromEntries: $0) }
     }
     
-    var entriesSummaryByWeekYear: [EntrySummary]? {
+    var entrySummaryByWeekYear: [EntrySummary]? {
         guard let startDate = entryInPeriod.first?.startDate,
               let finishDate = entryInPeriod.last?.finishDate,
               let timeDiff = Calendar.current.dateComponents([.month], from: startDate, to: finishDate).month,
-              timeDiff > 3,
+              timeDiff < 3,
               entryInPeriod.count < 60 else { return nil }
         return groupEntriesByYearWeek(entryInPeriod).map { EntrySummary(fromEntries: $0) }
     }

--- a/PunchPad/ViewModel/StatisticsViewModel.swift
+++ b/PunchPad/ViewModel/StatisticsViewModel.swift
@@ -90,6 +90,8 @@ class StatisticsViewModel: ObservableObject {
                         } catch {
                             print("Failed to generate chart time period with new `.all` range")
                         }
+                    } else {
+                        print("Failed to generate chart time period with new `.all` range when retrieving first and last entry")
                     }
                 }
             }.store(in: &subscriptions)
@@ -132,6 +134,29 @@ class StatisticsViewModel: ObservableObject {
                 return Calendar.current.dateComponents(dateComponentsToCompare, from: entry.startDate) == Calendar.current.dateComponents(dateComponentsToCompare, from: placeholder.startDate)
             }
             return replacer ?? placeholder
+        }
+        return result
+    }
+    
+    func createSummaryForAll(entries: [Entry]) -> [EntrySummary] {
+        let groupedEntries: [[Entry]] = {
+            var shouldGroupByMonth = false
+            if let startDate = entries.first?.startDate,
+               let finishDate = entries.last?.finishDate,
+               let timeDiff = Calendar.current.dateComponents([.month], from: startDate, to: finishDate).month {
+                shouldGroupByMonth = true
+            }
+            if entries.count > 60 || shouldGroupByMonth {
+                return self.groupEntriesByYearMonth(entries)
+            } else {
+                return self.groupEntriesByYearWeek(entries)
+            }
+        }()
+        
+        var result = [EntrySummary]()
+        for group in groupedEntries {
+            let summary = EntrySummary(fromEntries: group)
+            result.append(summary)
         }
         return result
     }

--- a/PunchPad/ViewModel/StatisticsViewModel.swift
+++ b/PunchPad/ViewModel/StatisticsViewModel.swift
@@ -8,12 +8,6 @@
 import Foundation
 import Combine
 
-enum ChartType {
-    case time, startTime, finishTime
-}
-
-
-typealias Period = (Date, Date)
 class StatisticsViewModel: ObservableObject {
     private var chartPeriodService: ChartPeriodService = .init(calendar: .current)
     @Published private var dataManager: DataManager

--- a/PunchPadTests/Extensions/Published+Extension.swift
+++ b/PunchPadTests/Extensions/Published+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  Published+Extension.swift
+//  PunchPadTests
+//
+//  Created by Tomasz Kubiak on 12/02/2024.
+//
+
+import Combine
+
+extension Published.Publisher {
+    /// Ignore initial value and collect N number of next values for a given published property
+    /// - Parameter count: number of values to collect
+    /// - Returns: type erased publisher emitng a single  array of collected output
+    func collectNext(_ count: Int) -> AnyPublisher<[Output], Never> {
+        self.dropFirst()
+            .collect(count)
+            .first()
+            .eraseToAnyPublisher()
+    }
+}

--- a/PunchPadTests/Extensions/XCTestCase+Extension.swift
+++ b/PunchPadTests/Extensions/XCTestCase+Extension.swift
@@ -1,0 +1,36 @@
+//
+//  XCTestCase+Extension.swift
+//  PunchPadTests
+//
+//  Created by Tomasz Kubiak on 12/02/2024.
+//
+
+import XCTest
+import Combine
+
+extension XCTestCase {
+    func awaitPublisher<T: Publisher>(_ publisher: T, timeout: TimeInterval = 2.5, file: StaticString = #file, line: UInt = #line) throws -> T.Output {
+        var result: Result<T.Output, Error>?
+        let expectation = self.expectation(description: "Awaiting publisher")
+        
+        let cancellable = publisher.sink { completion in
+            switch completion {
+            case .failure(let error):
+                result = .failure(error)
+            case .finished:
+                break
+            }
+            expectation.fulfill()
+        } receiveValue: { value in
+            result = .success(value)
+        }
+        waitForExpectations(timeout: timeout)
+        cancellable.cancel()
+        let unwrappedResult = try XCTUnwrap(result,
+                                            "Awaited publisher did not produce any output",
+                                            file: file,
+                                            line: line)
+        return try unwrappedResult.get()
+    }
+}
+

--- a/PunchPadTests/StatisticsViewModelTests.swift
+++ b/PunchPadTests/StatisticsViewModelTests.swift
@@ -22,6 +22,8 @@ final class StatisticsViewModelTests: XCTestCase {
 
     override func tearDown() {
         sut = nil
+        container.dataManager.deleteAll()
+        container = nil
     }
 
     func testEntriesForChart() {
@@ -59,5 +61,25 @@ final class StatisticsViewModelTests: XCTestCase {
         let result = sut.createPlaceholderEntries(for: inputPeriod)
         XCTAssertTrue(result[0].startDate == inputStartDate, "Results should start with entry with input start date")
         XCTAssertTrue(result.last?.startDate == expectedLastEntryDate, "Results should end with entry with input finish date")
+    }
+    
+    func test_createSummaryForAll_with29Entries() {
+        let testEntries = PreviewDataFactory.buildDataForPreviewForMonth(containing: Date(), using: .current)
+        for entry in testEntries {
+            container.dataManager.updateAndSave(entry: entry)
+        }
+        sut.chartTimeRange = .all
+        let result = sut.createSummaryForAll(entries: sut.entriesForChart)
+        XCTAssertEqual(result.count, 5)
+    }
+    
+    func test_createSummaryForAll_with365Entries() {
+        let testEntries = PreviewDataFactory.buildDataForPreviewForYear(containing: Date(), using: .current)
+        for entry in testEntries {
+            container.dataManager.updateAndSave(entry: entry)
+        }
+        sut.chartTimeRange = .all
+        let result = sut.createSummaryForAll(entries: sut.entriesForChart)
+        XCTAssertEqual(result.count, 12)
     }
 }

--- a/PunchPadTests/StatisticsViewModelTests.swift
+++ b/PunchPadTests/StatisticsViewModelTests.swift
@@ -17,7 +17,9 @@ final class StatisticsViewModelTests: XCTestCase {
         container = Container()
         sut = StatisticsViewModel(dataManager: container.dataManager,
                                   payManager: container.payManager,
-                                  settingsStore: container.settingsStore)
+                                  settingsStore: container.settingsStore,
+                                  calendar: .current
+        )
     }
 
     override func tearDown() {

--- a/PunchPadTests/StatisticsViewModelTests.swift
+++ b/PunchPadTests/StatisticsViewModelTests.swift
@@ -36,7 +36,7 @@ final class StatisticsViewModelTests: XCTestCase {
         XCTAssert(sut.periodDisplayed.0 < Date() && Date() < sut.periodDisplayed.1)
         XCTAssert(sut.entryInPeriod.isEmpty)
         XCTAssert(sut.entrySummaryByMonthYear.isEmpty)
-        XCTAssertNil(sut.entriesSummaryByWeekYear)
+        XCTAssertNil(sut.entrySummaryByWeekYear)
         XCTAssert(sut.workedHoursInPeriod == 0)
         XCTAssert(sut.overtimeHoursInPeriod == 0)
     }
@@ -124,7 +124,7 @@ final class StatisticsViewModelTests: XCTestCase {
         let result = try awaitPublisher(entriesPublisher)
         XCTAssertEqual(result.last?.count, expectedNumberOfEntries)
         XCTAssertEqual(sut.entrySummaryByMonthYear.count, 12)
-        XCTAssertNil(sut.entriesSummaryByWeekYear)
+        XCTAssertNil(sut.entrySummaryByWeekYear)
     }
     
     func test_entryInPeriod_udapted_whenUpdatingChartTimeRangeToAll_withYearOfEntries() throws {
@@ -142,7 +142,7 @@ final class StatisticsViewModelTests: XCTestCase {
         let result = try awaitPublisher(entriesPublisher)
         XCTAssertEqual(result.last?.count, expectedNumberOfEntries)
         XCTAssertEqual(sut.entrySummaryByMonthYear.count, 12)
-        XCTAssertNil(sut.entriesSummaryByWeekYear)
+        XCTAssertNil(sut.entrySummaryByWeekYear)
     }
     
     func test_entryInPeriod_updated_whenUpdatingChartTimeRangeToAll_withMonthOfEntries() throws {
@@ -161,7 +161,7 @@ final class StatisticsViewModelTests: XCTestCase {
         let result = try awaitPublisher(entriesPublisher)
         XCTAssertEqual(result.last?.count, expectedNumberOfEntries)
         XCTAssertEqual(sut.entrySummaryByMonthYear.count, 1)
-        let unwrappedSummaryByWeekYear = try XCTUnwrap(sut.entriesSummaryByWeekYear)
+        let unwrappedSummaryByWeekYear = try XCTUnwrap(sut.entrySummaryByWeekYear)
         XCTAssertEqual(unwrappedSummaryByWeekYear.count, expectedNumberOfWeeks)
     }
 }


### PR DESCRIPTION
In this PR an issue with missing implementation of displaying all data was solved. This PR significantly alters statistics view model, statistics view model tests, chart factory and data manager. Additional protocol ChartableEntry was added,

Chart factory functions were changed to one function, generic over data input. Additional helper functions were added.
Two additional function facilitating the building of period for `.all` were added to data manager - retrieving the oldest and newest entry from data container. 

Statistics view model was refactored to make better use of combine publishers. Updating values driving UI and pay manager are now done through combine publishers responding to changes in chart time and period, as well as changes in DataManager, as opposed to using computed properties.

Statistics view model tests were refactored and change to use subscription to publisher to drive tests in async manner. 
Additional XCTest extension for waiting for a publisher response was created. 