### PR TITLE
Add validating result is a number in indicator width calculation

### DIFF
--- a/PunchPad/Features/History/View/HistoryRowView.swift
+++ b/PunchPad/Features/History/View/HistoryRowView.swift
@@ -103,12 +103,14 @@ struct HistoryRowView: View {
     
     func getWorkTimeIndicatorWidth(in width: CGFloat) -> CGFloat {
         let fraction: Double = Double(workTimeInSeconds) / Double(maximumTime)
-        return width * CGFloat(fraction)
+        let result = width * CGFloat(fraction)
+        return result.isNaN ? 0 : result
     }
     
     func getOvertimeIndicatorWidth(in width: CGFloat) -> CGFloat {
         let fraction: Double = Double(overTimeInSeconds) / Double(maximumTime)
-        return width * CGFloat(fraction)
+        let result = width * CGFloat(fraction)
+        return result.isNaN ? 0 : result
     }
     
     private func makeTimeIntervalLabel(for timeInterval: TimeInterval) -> String {


### PR DESCRIPTION
The change resolves issue when the overtimeInSeconds or workTimeInSeconds are very small compared to maximumTime, resulting in a value of fraction being NaN. 

Fixed issue by checking if result is a valid number. If result is NaN, a zero will be returned from: 
- getOvertimeIndicatorWidth
- getWorkTimeIndicatorWidth