### PR TITLE
59 move datamanager to pop approach

### DIFF
--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		D6EA695E2AF8498D00D8F6C3 /* OnboardingOvertimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EA695D2AF8498D00D8F6C3 /* OnboardingOvertimeView.swift */; };
 		D6ED26BD2AA3B739001E2390 /* StatisticsViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED26BC2AA3B739001E2390 /* StatisticsViewScreen.swift */; };
 		D6ED26BF2AA3BA05001E2390 /* OnboardingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED26BE2AA3BA05001E2390 /* OnboardingUITests.swift */; };
+		D6EF97922BE7FB6900AD719C /* PreviewDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EF97912BE7FB6900AD719C /* PreviewDataManager.swift */; };
 		D6FA94FB2B013C770034B16A /* ChartLegendItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FA94FA2B013C770034B16A /* ChartLegendItem.swift */; };
 		D6FA94FD2B013F060034B16A /* ChartLegendItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FA94FC2B013F060034B16A /* ChartLegendItemView.swift */; };
 		D6FA94FF2B0145FF0034B16A /* ChartFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FA94FE2B0145FE0034B16A /* ChartFactory.swift */; };
@@ -265,6 +266,7 @@
 		D6EA695D2AF8498D00D8F6C3 /* OnboardingOvertimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingOvertimeView.swift; sourceTree = "<group>"; };
 		D6ED26BC2AA3B739001E2390 /* StatisticsViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewScreen.swift; sourceTree = "<group>"; };
 		D6ED26BE2AA3BA05001E2390 /* OnboardingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingUITests.swift; sourceTree = "<group>"; };
+		D6EF97912BE7FB6900AD719C /* PreviewDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDataManager.swift; sourceTree = "<group>"; };
 		D6FA94FA2B013C770034B16A /* ChartLegendItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartLegendItem.swift; sourceTree = "<group>"; };
 		D6FA94FC2B013F060034B16A /* ChartLegendItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartLegendItemView.swift; sourceTree = "<group>"; };
 		D6FA94FE2B0145FE0034B16A /* ChartFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartFactory.swift; sourceTree = "<group>"; };
@@ -723,6 +725,7 @@
 				D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */,
 				D65FD53C29D8B259006CC34F /* PersistanceController.swift */,
 				D64574AF29D9E6A000207168 /* DataManager.swift */,
+				D6EF97912BE7FB6900AD719C /* PreviewDataManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -937,6 +940,7 @@
 				D6C3567B2B44AAB4007C23A3 /* ButtonStyle+Extension.swift in Sources */,
 				D6CB2A7C2B05629200F3030C /* View+Extension.swift in Sources */,
 				D64574B029D9E6A000207168 /* DataManager.swift in Sources */,
+				D6EF97922BE7FB6900AD719C /* PreviewDataManager.swift in Sources */,
 				D6D906B12AA12BDB004E09C9 /* BackgroundFactory.swift in Sources */,
 				D6D02FB029EF0B7F006CD0B2 /* EditSheetViewModel.swift in Sources */,
 				D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		D64574B429D9F16900207168 /* EntryMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */; };
 		D64574B629D9F37400207168 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B529D9F37400207168 /* Entry.swift */; };
 		D64766C52AFEBD9D0013AC9A /* ChartLegendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64766C42AFEBD9D0013AC9A /* ChartLegendView.swift */; };
+		D64E6B112BE6B42000E961B6 /* DataManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64E6B102BE6B42000E961B6 /* DataManaging.swift */; };
 		D653FEEC2B320E1600ECFCF2 /* TimeIntervalPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D653FEEB2B320E1600ECFCF2 /* TimeIntervalPicker.swift */; };
 		D65A976B29F2E6B800462D8C /* StatisticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65A976A29F2E6B800462D8C /* StatisticsViewModelTests.swift */; };
 		D65A976F29F3BBDD00462D8C /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65A976E29F3BBDD00462D8C /* OnboardingView.swift */; };
@@ -188,6 +189,7 @@
 		D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntryMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D64574B529D9F37400207168 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		D64766C42AFEBD9D0013AC9A /* ChartLegendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartLegendView.swift; sourceTree = "<group>"; };
+		D64E6B102BE6B42000E961B6 /* DataManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DataManaging.swift; path = /Users/tomaszkubiak/xcode/PunchPad/PunchPad/Features/Persistance/Model/DataManaging.swift; sourceTree = "<absolute>"; };
 		D653FEEB2B320E1600ECFCF2 /* TimeIntervalPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIntervalPicker.swift; sourceTree = "<group>"; };
 		D65A976A29F2E6B800462D8C /* StatisticsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewModelTests.swift; sourceTree = "<group>"; };
 		D65A976E29F3BBDD00462D8C /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -716,6 +718,7 @@
 		D6FD094E2BCC490B00AD8989 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				D64E6B102BE6B42000E961B6 /* DataManaging.swift */,
 				D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */,
 				D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */,
 				D65FD53C29D8B259006CC34F /* PersistanceController.swift */,
@@ -918,6 +921,7 @@
 				D684A3882AF6F3E700511E0D /* OnboardingWelcomeView.swift in Sources */,
 				D6842EC429EC62DE00731E84 /* PayManager.swift in Sources */,
 				D64766C52AFEBD9D0013AC9A /* ChartLegendView.swift in Sources */,
+				D64E6B112BE6B42000E961B6 /* DataManaging.swift in Sources */,
 				D64574B629D9F37400207168 /* Entry.swift in Sources */,
 				D6E6832E2B79502B009C6CEC /* ChartableEntry.swift in Sources */,
 				D6C458C729D36C050069D89B /* RingView.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		D6ED26BD2AA3B739001E2390 /* StatisticsViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED26BC2AA3B739001E2390 /* StatisticsViewScreen.swift */; };
 		D6ED26BF2AA3BA05001E2390 /* OnboardingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED26BE2AA3BA05001E2390 /* OnboardingUITests.swift */; };
 		D6EF97922BE7FB6900AD719C /* PreviewDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EF97912BE7FB6900AD719C /* PreviewDataManager.swift */; };
+		D6EF97942BE81A4D00AD719C /* TestDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EF97932BE81A4D00AD719C /* TestDataManager.swift */; };
 		D6FA94FB2B013C770034B16A /* ChartLegendItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FA94FA2B013C770034B16A /* ChartLegendItem.swift */; };
 		D6FA94FD2B013F060034B16A /* ChartLegendItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FA94FC2B013F060034B16A /* ChartLegendItemView.swift */; };
 		D6FA94FF2B0145FF0034B16A /* ChartFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FA94FE2B0145FE0034B16A /* ChartFactory.swift */; };
@@ -267,6 +268,7 @@
 		D6ED26BC2AA3B739001E2390 /* StatisticsViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewScreen.swift; sourceTree = "<group>"; };
 		D6ED26BE2AA3BA05001E2390 /* OnboardingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingUITests.swift; sourceTree = "<group>"; };
 		D6EF97912BE7FB6900AD719C /* PreviewDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDataManager.swift; sourceTree = "<group>"; };
+		D6EF97932BE81A4D00AD719C /* TestDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataManager.swift; sourceTree = "<group>"; };
 		D6FA94FA2B013C770034B16A /* ChartLegendItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartLegendItem.swift; sourceTree = "<group>"; };
 		D6FA94FC2B013F060034B16A /* ChartLegendItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartLegendItemView.swift; sourceTree = "<group>"; };
 		D6FA94FE2B0145FE0034B16A /* ChartFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartFactory.swift; sourceTree = "<group>"; };
@@ -726,6 +728,7 @@
 				D65FD53C29D8B259006CC34F /* PersistanceController.swift */,
 				D64574AF29D9E6A000207168 /* DataManager.swift */,
 				D6EF97912BE7FB6900AD719C /* PreviewDataManager.swift */,
+				D6EF97932BE81A4D00AD719C /* TestDataManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -926,6 +929,7 @@
 				D64766C52AFEBD9D0013AC9A /* ChartLegendView.swift in Sources */,
 				D64E6B112BE6B42000E961B6 /* DataManaging.swift in Sources */,
 				D64574B629D9F37400207168 /* Entry.swift in Sources */,
+				D6EF97942BE81A4D00AD719C /* TestDataManager.swift in Sources */,
 				D6E6832E2B79502B009C6CEC /* ChartableEntry.swift in Sources */,
 				D6C458C729D36C050069D89B /* RingView.swift in Sources */,
 				D66A4DF62B7AA72800D16110 /* ChartType.swift in Sources */,

--- a/PunchPad/Features/ContainerService/Container.swift
+++ b/PunchPad/Features/ContainerService/Container.swift
@@ -17,8 +17,10 @@ final class Container: ContainerProtocol {
     init() {
         self.timerProvider = Timer.self
         self.settingsStore = SettingsStore()
-        self.dataManager = DataManager.shared
-        self.payManager = PayManager(dataManager: DataManager.shared, settingsStore: settingsStore, calendar: .current)
+        self.dataManager = DataManager()
+        self.payManager = PayManager(dataManager: dataManager,
+                                     settingsStore: settingsStore,
+                                     calendar: .current)
         self.notificationService = NotificationService(center: .current())
     }
 }

--- a/PunchPad/Features/ContainerService/Container.swift
+++ b/PunchPad/Features/ContainerService/Container.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class Container: ContainerProtocol {
-    private(set) var dataManager: DataManager
+    private(set) var dataManager: any DataManaging
     private(set) var payManager: PayManager
     private(set) var timerProvider: Timer.Type
     private(set) var settingsStore: SettingsStore
@@ -17,8 +17,8 @@ final class Container: ContainerProtocol {
     init() {
         self.timerProvider = Timer.self
         self.settingsStore = SettingsStore()
-        self.dataManager = .shared
-        self.payManager = PayManager(dataManager: .shared, settingsStore: settingsStore, calendar: .current)
+        self.dataManager = DataManager.shared
+        self.payManager = PayManager(dataManager: DataManager.shared, settingsStore: settingsStore, calendar: .current)
         self.notificationService = NotificationService(center: .current())
     }
 }

--- a/PunchPad/Features/ContainerService/ContainerProtocol.swift
+++ b/PunchPad/Features/ContainerService/ContainerProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol ContainerProtocol {
-    var dataManager: DataManager { get }
+    var dataManager: any DataManaging { get }
     var payManager: PayManager { get }
     var timerProvider: Timer.Type { get }
     var settingsStore: SettingsStore { get }

--- a/PunchPad/Features/ContainerService/PreviewContainer.swift
+++ b/PunchPad/Features/ContainerService/PreviewContainer.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class PreviewContainer: ContainerProtocol {
-    private(set) var dataManager: DataManager
+    private(set) var dataManager: any DataManaging
     private(set) var payManager: PayManager
     private(set) var timerProvider: Timer.Type
     private(set) var settingsStore: SettingsStore
@@ -18,8 +18,8 @@ final class PreviewContainer: ContainerProtocol {
         self.timerProvider = Timer.self
         SettingsStore.setTestUserDefaults()
         self.settingsStore = SettingsStore()
-        self.dataManager = .preview
-        self.payManager = PayManager(dataManager: .preview, settingsStore: settingsStore, calendar: .current)
+        self.dataManager = DataManager.preview
+        self.payManager = PayManager(dataManager: DataManager.preview, settingsStore: settingsStore, calendar: .current)
         self.notificationService = NotificationService(center: .current())
     }
 }

--- a/PunchPad/Features/ContainerService/PreviewContainer.swift
+++ b/PunchPad/Features/ContainerService/PreviewContainer.swift
@@ -15,11 +15,13 @@ final class PreviewContainer: ContainerProtocol {
     private(set) var notificationService: NotificationService
     
     init() {
-        self.timerProvider = Timer.self
         SettingsStore.setTestUserDefaults()
+        self.timerProvider = Timer.self
         self.settingsStore = SettingsStore()
         self.dataManager = PreviewDataManager()
-        self.payManager = PayManager(dataManager: DataManager.preview, settingsStore: settingsStore, calendar: .current)
+        self.payManager = PayManager(dataManager: dataManager,
+                                     settingsStore: settingsStore,
+                                     calendar: .current)
         self.notificationService = NotificationService(center: .current())
     }
 }

--- a/PunchPad/Features/ContainerService/PreviewContainer.swift
+++ b/PunchPad/Features/ContainerService/PreviewContainer.swift
@@ -18,7 +18,7 @@ final class PreviewContainer: ContainerProtocol {
         self.timerProvider = Timer.self
         SettingsStore.setTestUserDefaults()
         self.settingsStore = SettingsStore()
-        self.dataManager = DataManager.preview
+        self.dataManager = PreviewDataManager()
         self.payManager = PayManager(dataManager: DataManager.preview, settingsStore: settingsStore, calendar: .current)
         self.notificationService = NotificationService(center: .current())
     }

--- a/PunchPad/Features/ContainerService/TestContainer.swift
+++ b/PunchPad/Features/ContainerService/TestContainer.swift
@@ -15,11 +15,13 @@ final class TestContainer: ContainerProtocol {
     private(set) var notificationService: NotificationService
     
     init() {
-        self.timerProvider = Timer.self
         SettingsStore.setTestUserDefaults()
+        self.timerProvider = Timer.self
         self.settingsStore = SettingsStore()
-        self.dataManager = DataManager.testing
-        self.payManager = PayManager(dataManager: DataManager.testing, settingsStore: settingsStore, calendar: .current)
+        self.dataManager = TestDataManager()
+        self.payManager = PayManager(dataManager: dataManager, 
+                                     settingsStore: settingsStore,
+                                     calendar: .current)
         self.notificationService = NotificationService(center: .current())
     }
 }

--- a/PunchPad/Features/ContainerService/TestContainer.swift
+++ b/PunchPad/Features/ContainerService/TestContainer.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class TestContainer: ContainerProtocol {
-    private(set) var dataManager: DataManager
+    private(set) var dataManager: any DataManaging
     private(set) var payManager: PayManager
     private(set) var timerProvider: Timer.Type
     private(set) var settingsStore: SettingsStore
@@ -18,8 +18,8 @@ final class TestContainer: ContainerProtocol {
         self.timerProvider = Timer.self
         SettingsStore.setTestUserDefaults()
         self.settingsStore = SettingsStore()
-        self.dataManager = .testing
-        self.payManager = PayManager(dataManager: .testing, settingsStore: settingsStore, calendar: .current)
+        self.dataManager = DataManager.testing
+        self.payManager = PayManager(dataManager: DataManager.testing, settingsStore: settingsStore, calendar: .current)
         self.notificationService = NotificationService(center: .current())
     }
 }

--- a/PunchPad/Features/History/ViewModel/EditSheetViewModel.swift
+++ b/PunchPad/Features/History/ViewModel/EditSheetViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 final class EditSheetViewModel: ObservableObject {
-    private var dataManager: DataManager
+    private var dataManager: any DataManaging
     private var settingsStore: SettingsStore
     private var payService: PayManager
     private var entry: Entry
@@ -43,7 +43,7 @@ final class EditSheetViewModel: ObservableObject {
         CGFloat(overTimeInSeconds / currentMaximumOvertime)
     }
     
-    init(dataManager: DataManager,  settingsStore: SettingsStore, payService: PayManager, calendar: Calendar = .current, entry: Entry) {
+    init(dataManager: any DataManaging,  settingsStore: SettingsStore, payService: PayManager, calendar: Calendar = .current, entry: Entry) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
         self.payService = payService

--- a/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
+++ b/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Combine
 
 class HomeViewModel: NSObject, ObservableObject {
-    private var dataManager: DataManager
+    private var dataManager: any DataManaging
     private var settingsStore: SettingsStore
     private var payManager: PayManager
     private var notificationService: NotificationService
@@ -39,7 +39,7 @@ class HomeViewModel: NSObject, ObservableObject {
         overtimeTimerService?.progress ?? 0
     }
     
-    init(dataManager: DataManager, settingsStore: SettingsStore, payManager: PayManager, notificationService: NotificationService, timerProvider: Timer.Type) {
+    init(dataManager: any DataManaging, settingsStore: SettingsStore, payManager: PayManager, notificationService: NotificationService, timerProvider: Timer.Type) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
         self.timerProvider = timerProvider

--- a/PunchPad/Features/PayService/PayManager.swift
+++ b/PunchPad/Features/PayService/PayManager.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 final class PayManager: ObservableObject {
-    private var dataManager: DataManager
+    private var dataManager: any DataManaging
     private var settingsStore: SettingsStore
     private var calendar: Calendar
     private var overtimePayCoef: Double = 1.5
@@ -17,7 +17,7 @@ final class PayManager: ObservableObject {
     @Published private var currentPeriod: Period
     @Published private(set) var grossDataForPeriod: GrossSalary
     
-    init(dataManager: DataManager, settingsStore: SettingsStore, currentPeriod: Period = (Date(), Date()), calendar: Calendar) {
+    init(dataManager: any DataManaging, settingsStore: SettingsStore, currentPeriod: Period = (Date(), Date()), calendar: Calendar) {
         self.settingsStore = settingsStore
         self.dataManager = dataManager
         self.currentPeriod = currentPeriod
@@ -37,7 +37,7 @@ final class PayManager: ObservableObject {
             self?.objectWillChange.send()
         }.store(in: &subscriptions)
         
-        dataManager.objectWillChange.sink { [weak self] _ in
+        dataManager.dataDidChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }.store(in: &subscriptions)
     }

--- a/PunchPad/Features/Persistance/Model/DataManager.swift
+++ b/PunchPad/Features/Persistance/Model/DataManager.swift
@@ -56,7 +56,7 @@ final class DataManager: NSObject, DataManaging {
     
     //MARK: HELPER METHODS
     ///Checks for changes in the managed object context and saves if uncommited changes are present
-    func saveContext() {
+    private func saveContext() {
         if managedObjectContext.hasChanges {
             do {
                 try managedObjectContext.save()

--- a/PunchPad/Features/Persistance/Model/DataManager.swift
+++ b/PunchPad/Features/Persistance/Model/DataManager.swift
@@ -14,7 +14,7 @@ enum DataManagerType {
 }
 
 final class DataManager: NSObject, DataManaging {
-    
+    let dataDidChange = PassthroughSubject<Void, Never>()
     //MARK: STATIC INSTANCES
     static let shared = DataManager(type: .normal)
     static let preview = DataManager(type: .preview)
@@ -40,7 +40,7 @@ final class DataManager: NSObject, DataManaging {
         //Notify of change anytime CD changes
         NotificationCenter.default.publisher(for: Notification.Name.NSManagedObjectContextDidSave)
             .sink { [weak self] _ in
-                self?.objectWillChange.send()
+                self?.dataDidChange.send()
             }
             .store(in: &cancellables)
         

--- a/PunchPad/Features/Persistance/Model/DataManaging.swift
+++ b/PunchPad/Features/Persistance/Model/DataManaging.swift
@@ -1,0 +1,22 @@
+//
+//  DataManaging.swift
+//  
+//
+//  Created by Tomasz Kubiak on 04/05/2024.
+//
+
+import Foundation
+import Combine
+
+protocol DataManaging: NSObject {
+    var dataDidChange: PassthroughSubject<Void, Never> { get }
+    func saveContext()
+    func updateAndSave(entry: Entry)
+    func delete(entry: Entry)
+    func deleteAll()
+    func fetch(forDate: Date) -> Entry?
+    func fetch(for: Period) -> [Entry]?
+    func fetch(from: Date?, to: Date?, ascendingOrder: Bool, fetchLimit: Int?) -> [Entry]?
+    func fetchOldestExisting() -> Entry?
+    func fetchNewestExisting() -> Entry?
+}

--- a/PunchPad/Features/Persistance/Model/DataManaging.swift
+++ b/PunchPad/Features/Persistance/Model/DataManaging.swift
@@ -10,7 +10,6 @@ import Combine
 
 protocol DataManaging: NSObject {
     var dataDidChange: PassthroughSubject<Void, Never> { get }
-    func saveContext()
     func updateAndSave(entry: Entry)
     func delete(entry: Entry)
     func deleteAll()

--- a/PunchPad/Features/Persistance/Model/PreviewDataManager.swift
+++ b/PunchPad/Features/Persistance/Model/PreviewDataManager.swift
@@ -1,0 +1,76 @@
+//
+//  PreviewDataManager.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 05/05/2024.
+//
+
+import Foundation
+import Combine
+
+final class PreviewDataManager: NSObject, DataManaging {
+    var dataDidChange = PassthroughSubject<Void, Never>()
+    private var data = [Entry]()
+    
+    init(with initialData: [Entry] = PreviewDataFactory.buildDataForPreviewForYear()) {
+        super.init()
+        data = initialData
+        dataDidChange.send()
+    }
+    
+    func updateAndSave(entry: Entry) {
+        data.append(entry)
+        dataDidChange.send()
+    }
+    
+    func delete(entry: Entry) {
+        data.removeAll { $0.id == entry.id }
+        dataDidChange.send()
+    }
+    
+    func deleteAll() {
+        data = .init()
+        dataDidChange.send()
+    }
+    
+    func fetch(forDate date: Date) -> Entry? {
+        data.first { Calendar.current.isDate($0.startDate, inSameDayAs: date) }
+    }
+    
+    func fetch(for period: Period) -> [Entry]? {
+        fetch(from: period.0, to: period.1)
+    }
+    
+    func fetch(from startDate: Date?, to finishDate: Date?, ascendingOrder: Bool = false, fetchLimit: Int? = nil) -> [Entry]? {
+        var result = data.filter { data in
+            if let startDate, let finishDate {
+                return data.finishDate > startDate && data.finishDate < finishDate
+            } else if let startDate {
+                return data.finishDate > startDate
+            } else if let finishDate {
+                return data.finishDate < finishDate
+            }
+            return true
+        }
+        
+        if ascendingOrder {
+            result.sort(by: { $0.finishDate < $1.finishDate })
+        } else {
+            result.sort(by: { $0.finishDate > $1.finishDate})
+        }
+        
+        if let fetchLimit, result.count > fetchLimit {
+            return result.dropLast(result.count - fetchLimit)
+        }
+        
+        return result
+    }
+    
+    func fetchOldestExisting() -> Entry? {
+        data.min { $0.startDate < $1.startDate }
+    }
+    
+    func fetchNewestExisting() -> Entry? {
+        data.max { $0.startDate > $1.startDate }
+    }
+}

--- a/PunchPad/Features/Persistance/Model/TestDataManager.swift
+++ b/PunchPad/Features/Persistance/Model/TestDataManager.swift
@@ -1,0 +1,8 @@
+//
+//  TestDataManager.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 05/05/2024.
+//
+
+import Foundation

--- a/PunchPad/Features/Persistance/Model/TestDataManager.swift
+++ b/PunchPad/Features/Persistance/Model/TestDataManager.swift
@@ -42,6 +42,11 @@ final class TestDataManager: NSObject {
         entry.grossPayPerMonth = 10000
         saveContext()
     }
+    
+    func numberOfEntries() throws -> Int {
+        let request: NSFetchRequest<EntryMO> = EntryMO.fetchRequest()
+        return try managedObjectContext.count(for: request)
+    }
 }
 
 extension TestDataManager: DataManaging {

--- a/PunchPad/Features/Persistance/Model/TestDataManager.swift
+++ b/PunchPad/Features/Persistance/Model/TestDataManager.swift
@@ -6,3 +6,231 @@
 //
 
 import Foundation
+import CoreData
+import Combine
+
+final class TestDataManager: NSObject {
+    let dataDidChange = PassthroughSubject<Void, Never>()
+    private var cancellables = Set<AnyCancellable>()
+    private var managedObjectContext: NSManagedObjectContext
+    
+    override init() {
+        let persistanceController = PersistanceController(inMemory: true)
+        self.managedObjectContext = persistanceController.viewContext
+        super.init()
+        
+        NotificationCenter.default.publisher(for: Notification.Name.NSManagedObjectContextDidSave)
+            .sink { [weak self] _ in
+                self?.dataDidChange.send()
+            }.store(in: &cancellables)
+        
+        addTestingData()
+    }
+    
+    private func addTestingData() {
+        var dateComponents = Calendar.current.dateComponents([.month,.year], from: Date())
+        dateComponents.day = 1
+        let date = Calendar.current.date(from: dateComponents)!
+        let entry = EntryMO(context: managedObjectContext)
+        entry.id = UUID()
+        entry.startDate = Calendar.current.date(byAdding: .hour, value: 6, to: date)!
+        entry.finishDate = Calendar.current.date(byAdding: DateComponents(hour: 14, minute: 30), to: date)!
+        entry.overTime = Int64(1 * 1800)
+        entry.workTime = 8 * 3600
+        entry.maximumOvertimeAllowedInSeconds = 5 * 3600
+        entry.standardWorktimeInSeconds = 8 * 3600
+        entry.grossPayPerMonth = 10000
+        saveContext()
+    }
+}
+
+extension TestDataManager: DataManaging {
+    func updateAndSave(entry: Entry) {
+        let predicate = NSPredicate(format: "id = %@", entry.id as CVarArg)
+        let result = fetchFirst(EntryMO.self, predicate: predicate)
+        switch result {
+        case .success(let managedObject):
+            if let entryMO = managedObject {
+                update(entryMO: entryMO, from: entry)
+            } else {
+                entryMO(from: entry)
+            }
+        case .failure(let error):
+            print("Could not fetch Entry to save - \(error): \(error.localizedDescription)")
+        }
+        saveContext()
+    }
+    
+    func delete(entry: Entry) {
+        let predicate = NSPredicate(format: "id = %@", entry.id as CVarArg)
+        let result = fetchFirst(EntryMO.self, predicate: predicate)
+        switch result {
+        case .success(let managedObject):
+            if let entryMO = managedObject {
+                managedObjectContext.delete(entryMO)
+            }
+        case .failure(let failure):
+            print("Could not fetch entry to delete: \(failure.localizedDescription)")
+        }
+        saveContext()
+    }
+    
+    func deleteAll() {
+        let request: NSFetchRequest<EntryMO> = EntryMO.fetchRequest()
+        do {
+            let result = try managedObjectContext.fetch(request)
+            for entryMO in result {
+                managedObjectContext.delete(entryMO)
+            }
+            saveContext()
+        } catch let error {
+            print("Delete all function failed to delete all objects - \(error):\(error.localizedDescription)")
+        }
+    }
+    
+    func fetch(forDate date: Date) -> Entry? {
+        let startDate = Calendar.current.startOfDay(for: date)
+        guard let finishDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate) else {
+            print("Could not build a date for the end of the day")
+            return nil }
+        let startPredicate = NSPredicate(format: "finishDate > %@", startDate as CVarArg)
+        let finishPredicate = NSPredicate(format: "finishDate < %@", finishDate as CVarArg)
+        let compPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [startPredicate, finishPredicate])
+        
+        let result = fetchFirst(EntryMO.self, predicate: compPredicate)
+        
+        switch result {
+        case .success(let resultObject):
+            if let entryMO = resultObject {
+                return Entry(entryMO: entryMO)
+            } else {
+                return nil
+            }
+        case .failure(let error):
+            print("Could not fech any entries for given date - \(error): \(error.localizedDescription)")
+            return nil
+        }
+    }
+    
+    func fetch(for period: Period) -> [Entry]? {
+        return fetch(from: period.0, to: period.1)
+    }
+    
+    func fetch(from startDate: Date?, to finishDate: Date?, ascendingOrder: Bool = false, fetchLimit: Int? = nil) -> [Entry]? {
+        let request: NSFetchRequest<EntryMO> = EntryMO.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "startDate", ascending: ascendingOrder)]
+        var subpredicates = [NSPredicate]()
+        
+        if let startDate {
+            let startPredicate = NSPredicate(format: "finishDate > %@", startDate as CVarArg)
+            subpredicates.append(startPredicate)
+        }
+        if let finishDate {
+            let finishPredicate = NSPredicate(format: "finishDate < %@", finishDate as CVarArg)
+            subpredicates.append(finishPredicate)
+        }
+        if let fetchLimit {
+            request.fetchLimit = fetchLimit
+        }
+        
+        let compPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
+        request.predicate = compPredicate
+        
+        do {
+            let result = try managedObjectContext.fetch(request)
+            return result.map({ Entry(entryMO: $0) })
+        } catch {
+            return nil
+        }
+    }
+    
+    func fetchOldestExisting() -> Entry? {
+        let sortDescriptor = NSSortDescriptor(key: "startDate", ascending: true)
+        let result = fetchFirst(EntryMO.self, predicate: nil, sortDescriptors: [sortDescriptor])
+        switch result {
+        case .success(let success):
+            if let entryMO = success {
+                return Entry(entryMO: entryMO)
+            } else {
+                return nil
+            }
+        case .failure(_):
+            return nil
+        }
+    }
+    
+    func fetchNewestExisting() -> Entry? {
+        let sortDescriptor = NSSortDescriptor(key: "startDate", ascending: false)
+        let result = fetchFirst(EntryMO.self, predicate: nil, sortDescriptors: [sortDescriptor])
+        switch result {
+        case .success(let success):
+            if let entryMO = success {
+                return Entry(entryMO: entryMO)
+            } else {
+                return nil
+            }
+        case .failure(_):
+            return nil
+        }
+    }
+}
+
+//MARK: - Core Data Helper Functions
+private extension TestDataManager {
+    func saveContext() {
+        if managedObjectContext.hasChanges {
+            do {
+                try managedObjectContext.save()
+            } catch let error {
+                print("Error saving: \(error) - \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func fetchFirst<T: NSManagedObject>(_ objectType: T.Type, predicate: NSPredicate?, sortDescriptors: [NSSortDescriptor]? = nil) -> Result<T?, Error> {
+        let request = objectType.fetchRequest()
+        request.predicate = predicate
+        request.fetchLimit = 1
+        request.sortDescriptors = sortDescriptors
+        do {
+            let result = try managedObjectContext.fetch(request) as? [T]
+            return .success(result?.first)
+        } catch {
+            return .failure(error)
+        }
+    }
+    
+    func entryMO(from entry: Entry) {
+        let entryMO = EntryMO(context: managedObjectContext)
+        entryMO.id = entry.id
+        update(entryMO: entryMO, from: entry)
+    }
+    
+    func update(entryMO: EntryMO, from entry: Entry) {
+        entryMO.startDate = entry.startDate
+        entryMO.finishDate = entry.finishDate
+        entryMO.workTime = Int64(entry.workTimeInSeconds)
+        entryMO.overTime = Int64(entry.overTimeInSeconds)
+        entryMO.maximumOvertimeAllowedInSeconds = Int64(entry.maximumOvertimeAllowedInSeconds)
+        entryMO.standardWorktimeInSeconds = Int64(entry.standardWorktimeInSeconds)
+        entryMO.grossPayPerMonth = Int64(entry.grossPayPerMonth)
+        if let netPay = entry.calculatedNetPay {
+            entryMO.calculatedNetPay = Double(netPay)
+        }
+    }
+}
+
+//MARK: - Entry Conv Init
+fileprivate extension Entry {
+    init(entryMO: EntryMO) {
+        self.id = entryMO.id
+        self.startDate = entryMO.startDate
+        self.finishDate = entryMO.finishDate
+        self.workTimeInSeconds = Int(entryMO.workTime)
+        self.overTimeInSeconds = Int(entryMO.overTime)
+        self.maximumOvertimeAllowedInSeconds = Int(entryMO.maximumOvertimeAllowedInSeconds)
+        self.standardWorktimeInSeconds = Int(entryMO.standardWorktimeInSeconds)
+        self.grossPayPerMonth = Int(entryMO.grossPayPerMonth)
+        self.calculatedNetPay = Double(entryMO.calculatedNetPay)
+    }
+}

--- a/PunchPad/Features/Setting/ViewModel/SettingViewModel.swift
+++ b/PunchPad/Features/Setting/ViewModel/SettingViewModel.swift
@@ -11,7 +11,7 @@ import SwiftUI
 final class SettingsViewModel: ObservableObject {
     private var subscriptions = Set<AnyCancellable>()
     private var notificationService: NotificationService
-    private var dataManager: DataManager
+    private var dataManager: any DataManaging
     private let secondsInHour = 3600
     private let secondsInMinute = 60
     @Published var settingsStore: SettingsStore
@@ -22,7 +22,7 @@ final class SettingsViewModel: ObservableObject {
     @Published var grossPayPerMonth: Int
     @Published var shouldShowNotificationDeniedAlert: Bool = false
     
-    init(dataManger: DataManager, notificationService: NotificationService, settingsStore: SettingsStore) {
+    init(dataManger: any DataManaging, notificationService: NotificationService, settingsStore: SettingsStore) {
         self.dataManager = dataManger
         self.notificationService = notificationService
         self.settingsStore = settingsStore

--- a/PunchPad/Features/Statistics/ViewModel/StatisticsViewModel.swift
+++ b/PunchPad/Features/Statistics/ViewModel/StatisticsViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 final class StatisticsViewModel: ObservableObject {
     private var chartPeriodService: ChartPeriodService
     private var calendar: Calendar
-    @Published private var dataManager: DataManager
+    private var dataManager: any DataManaging
     @Published private var payManager: PayManager
     @Published private var settingsStore: SettingsStore
     private var subscriptions = Set<AnyCancellable>()
@@ -46,7 +46,7 @@ final class StatisticsViewModel: ObservableObject {
         return groupEntriesByYearWeek(entryInPeriod).map { EntrySummary(fromEntries: $0) }
     }
     
-    init(dataManager: DataManager, payManager: PayManager, settingsStore: SettingsStore, calendar: Calendar) {
+    init(dataManager: any DataManaging, payManager: PayManager, settingsStore: SettingsStore, calendar: Calendar) {
         self.dataManager = dataManager
         self.payManager = payManager
         self.settingsStore = settingsStore
@@ -116,7 +116,7 @@ final class StatisticsViewModel: ObservableObject {
                 return self.fetchEntriesWithPlaceholders(for: period)
             }.assign(to: &$entryInPeriod)
         
-        dataManager.objectWillChange.sink { [weak self] _ in
+        dataManager.dataDidChange.sink { [weak self] _ in
             guard let self else { return }
             self.entryInPeriod = self.fetchEntriesWithPlaceholders(for: periodDisplayed)
         }.store(in: &subscriptions)

--- a/PunchPadTests/EditSheetViewModelTests.swift
+++ b/PunchPadTests/EditSheetViewModelTests.swift
@@ -9,8 +9,8 @@ import XCTest
 @testable import PunchPad
 
 final class EditSheetViewModelTests: XCTestCase {
-    
     var sut: EditSheetViewModel!
+    var testContainer: TestContainer!
     let entry: Entry = {
         let startOfDay = Calendar.current.startOfDay(for: Date())
         let startDate = Calendar.current.date(byAdding: .hour, value: 6, to: startOfDay)!
@@ -28,13 +28,13 @@ final class EditSheetViewModelTests: XCTestCase {
     }()
     
     override func setUp() {
-        
+        testContainer = TestContainer()
         SettingsStore.setTestUserDefaults()
-        let settingStore = SettingsStore()
-        
-        sut = .init(dataManager: .testing,
-                    settingsStore: settingStore,
-                    payService: PayManager(dataManager: .testing, settingsStore: settingStore, calendar: .current),
+        sut = .init(dataManager: testContainer.dataManager,
+                    settingsStore: testContainer.settingsStore,
+                    payService: PayManager(dataManager: testContainer.dataManager,
+                                           settingsStore: testContainer.settingsStore,
+                                           calendar: .current),
                     calendar: .current,
                     entry: entry)
     }
@@ -42,6 +42,7 @@ final class EditSheetViewModelTests: XCTestCase {
     override func tearDown() {
         SettingsStore.clearUserDefaults()
         sut = nil
+        testContainer = nil
     }
 
     func test_adjustToEqualDateComponents() throws {

--- a/PunchPadTests/HomeViewModelTests.swift
+++ b/PunchPadTests/HomeViewModelTests.swift
@@ -538,7 +538,7 @@ extension HomeViewModelModelTests {
     
     private func numberOfEntries() throws -> Int {
         guard let manager = testContainer.dataManager as? TestDataManager else { throw TestError.failedToCast }
-        return manager.numberOfEntries()
+        return try manager.numberOfEntries()
     }
     
     enum TestError: Error {

--- a/PunchPadTests/PayManagerTests.swift
+++ b/PunchPadTests/PayManagerTests.swift
@@ -11,18 +11,16 @@ import CoreData
 
 final class PayManagerTests: XCTestCase {
     var sut: PayManager!
-    var settingsStore: SettingsStore!
-    var dataManager: DataManager!
+    var testContainer: TestContainer!
     var periodService: ChartPeriodService!
     
     override func setUp() {
         super.setUp()
-        dataManager = DataManager.testing
-        dataManager.deleteAll()
         SettingsStore.setTestUserDefaults()
-        settingsStore = SettingsStore()
-        sut = .init(dataManager: dataManager,
-                    settingsStore: settingsStore,
+        testContainer = TestContainer()
+        testContainer.dataManager.deleteAll()
+        sut = .init(dataManager: testContainer.dataManager,
+                    settingsStore: testContainer.settingsStore,
                     calendar: .current)
         periodService = ChartPeriodService(calendar: .current)
     }
@@ -30,8 +28,7 @@ final class PayManagerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         sut = nil
-        settingsStore = nil
-        dataManager = nil
+        testContainer = nil
     }
 }
 
@@ -45,14 +42,14 @@ extension PayManagerTests {
             XCTFail("Failed to prepare test data in \(#function)")
             return
         }
-        let expectedPayHour = Double(settingsStore.grossPayPerMonth) / Double(numberOfDayInMonth * 8)
+        let expectedPayHour = Double(testContainer.settingsStore.grossPayPerMonth) / Double(numberOfDayInMonth * 8)
         let expectedNumberOfWorkingDays = 5
         let expectedPayToDate = expectedPayHour * 40
         _ = addTestData(forPeriod: testPeriod,
-                    workTimeInSec: 8 * 3600,
-                    overtimeInSec: 0, standardWorkTimeInSec: 8 * 3600,
-                    maximumOvertimeInSec: 5 * 3600,
-                    grossPayPerMonth: settingsStore.grossPayPerMonth
+                        workTimeInSec: 8 * 3600,
+                        overtimeInSec: 0, standardWorkTimeInSec: 8 * 3600,
+                        maximumOvertimeInSec: 5 * 3600,
+                        grossPayPerMonth: testContainer.settingsStore.grossPayPerMonth
         )
         //When
         sut.updatePeriod(with: testPeriod)
@@ -72,15 +69,15 @@ extension PayManagerTests {
             XCTFail("Failed to prepare test data in \(#function)")
             return
         }
-        let expectedPayHour = Double(settingsStore.grossPayPerMonth) / Double(numberOfWorkingDays * 8)
+        let expectedPayHour = Double(testContainer.settingsStore.grossPayPerMonth) / Double(numberOfWorkingDays * 8)
         let expectedNumberOfWorkingDays = numberOfWorkingDays
-        let expectedPayToDate = Double(settingsStore.grossPayPerMonth)
+        let expectedPayToDate = Double(testContainer.settingsStore.grossPayPerMonth)
         _ = addTestData(forPeriod: testPeriod,
                     workTimeInSec: 8 * 3600,
                     overtimeInSec: 0,
                     standardWorkTimeInSec: 8 * 3600,
                     maximumOvertimeInSec: 5 * 3600,
-                    grossPayPerMonth: settingsStore.grossPayPerMonth
+                    grossPayPerMonth: testContainer.settingsStore.grossPayPerMonth
         )
         //When
         sut.updatePeriod(with: testPeriod)
@@ -100,14 +97,14 @@ extension PayManagerTests {
             return
         }
         let expectedNumberOfWorkingDays = numberOfWorkingDays(in: testPeriod)
-        let expectedPayHour = Double(12 * settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDays * 8)
-        let expectedPayToDate = Double(12 * settingsStore.grossPayPerMonth)
+        let expectedPayHour = Double(12 * testContainer.settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDays * 8)
+        let expectedPayToDate = Double(12 * testContainer.settingsStore.grossPayPerMonth)
         _ = addTestData(forPeriod: testPeriod,
                     workTimeInSec: 8 * 3600,
                     overtimeInSec: 0,
                     standardWorkTimeInSec: 8 * 3600,
                     maximumOvertimeInSec: 5 * 3600,
-                    grossPayPerMonth: settingsStore.grossPayPerMonth
+                    grossPayPerMonth: testContainer.settingsStore.grossPayPerMonth
         )
         //When
         sut.updatePeriod(with: testPeriod)
@@ -133,7 +130,7 @@ extension PayManagerTests {
         }
         let dataPeriod = (initialPeriod.0, endOfToday)
         let expectedNumberOfWorkingDaysInPeriod = numberOfWorkingDays(in: initialPeriod)
-        let expectedPayPerHour = Double(settingsStore.grossPayPerMonth) / Double(numberOfWorkingDaysInMonth * 8)
+        let expectedPayPerHour = Double(testContainer.settingsStore.grossPayPerMonth) / Double(numberOfWorkingDaysInMonth * 8)
         let expectedPayPrediced = expectedPayPerHour * Double(expectedNumberOfWorkingDaysInPeriod) * 8
         let expectedPayUpToDate = Double(numberOfWorkingDays(in: dataPeriod)) * 8 * expectedPayPerHour
         _ = addTestData(forPeriod: dataPeriod,
@@ -141,7 +138,7 @@ extension PayManagerTests {
                     overtimeInSec: 0,
                     standardWorkTimeInSec: 8 * 3600,
                     maximumOvertimeInSec: 5 * 3600,
-                    grossPayPerMonth: settingsStore.grossPayPerMonth
+                    grossPayPerMonth: testContainer.settingsStore.grossPayPerMonth
         )
         //When
         sut.updatePeriod(with: initialPeriod)
@@ -163,7 +160,7 @@ extension PayManagerTests {
         }
         let dataPeriod = (initialPeriod.0, endOfToday)
         let expectedNumberOfWorkingDaysInPeriod = numberOfWorkingDays(in: initialPeriod)
-        let expectedPayPerHour = Double(settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDaysInPeriod * 8)
+        let expectedPayPerHour = Double(testContainer.settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDaysInPeriod * 8)
         let expectedPayPrediced = expectedPayPerHour * Double(expectedNumberOfWorkingDaysInPeriod * 8)
         let expectedPayUpToDate = Double(numberOfWorkingDays(in: dataPeriod)) * 8 * expectedPayPerHour
         _ = addTestData(forPeriod: dataPeriod,
@@ -171,7 +168,7 @@ extension PayManagerTests {
                     overtimeInSec: 0,
                     standardWorkTimeInSec: 8 * 3600,
                     maximumOvertimeInSec: 5 * 3600,
-                    grossPayPerMonth: settingsStore.grossPayPerMonth
+                    grossPayPerMonth: testContainer.settingsStore.grossPayPerMonth
         )
         //When
         sut.updatePeriod(with: initialPeriod)
@@ -193,14 +190,14 @@ extension PayManagerTests {
         }
         let dataPeriod = (initialPeriod.0, endOfToday)
         let expectedNumberOfWorkingDaysInPeriod = numberOfWorkingDays(in: initialPeriod)
-        let expectedPayPerHour = Double(12 * settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDaysInPeriod * 8)
-        let expectedPayPrediced = Double(12 * settingsStore.grossPayPerMonth)
+        let expectedPayPerHour = Double(12 * testContainer.settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDaysInPeriod * 8)
+        let expectedPayPrediced = Double(12 * testContainer.settingsStore.grossPayPerMonth)
         let addedEntries = addTestData(forPeriod: dataPeriod,
                     workTimeInSec: 8 * 3600,
                     overtimeInSec: 0,
                     standardWorkTimeInSec: 8 * 3600,
                     maximumOvertimeInSec: 5 * 3600,
-                    grossPayPerMonth: settingsStore.grossPayPerMonth
+                    grossPayPerMonth: testContainer.settingsStore.grossPayPerMonth
         )
         let expectedPayUpToDate: Double =
             addedEntries.map { [weak self] entry in
@@ -232,7 +229,7 @@ extension PayManagerTests {
             return
         }
         let expectedNumberOfWorkingDays = 5
-        let expectedPayPerHour = Double(settingsStore.grossPayPerMonth) / Double(numberOfWorkingDaysInMonth * 8)
+        let expectedPayPerHour = Double(testContainer.settingsStore.grossPayPerMonth) / Double(numberOfWorkingDaysInMonth * 8)
         let expectedPayUpToDate: Double = 0
         //When
         sut.updatePeriod(with: period)
@@ -253,7 +250,7 @@ extension PayManagerTests {
             XCTFail("FAILED TO PREPARE INPUT DATA")
             return
         }
-        let expectedPayPerHour = Double(settingsStore.grossPayPerMonth) / (Double(numberOfWorkingDaysInMonth) * 8)
+        let expectedPayPerHour = Double(testContainer.settingsStore.grossPayPerMonth) / (Double(numberOfWorkingDaysInMonth) * 8)
         let expectedNumberOfWorkingDays = numberOfWorkingDaysInMonth
         let expectedPayUpToDate: Double = 0
         //When
@@ -275,7 +272,7 @@ extension PayManagerTests {
             return
         }
         let expectedNumberOfWorkingDays = numberOfWorkingDays(in: period)
-        let expectedPayPerHour = Double(12 * settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDays * 8)
+        let expectedPayPerHour = Double(12 * testContainer.settingsStore.grossPayPerMonth) / Double(expectedNumberOfWorkingDays * 8)
         let expectedPayUpToDate: Double = 0
         //When
         sut.updatePeriod(with: period)
@@ -342,7 +339,7 @@ extension PayManagerTests {
             )
         }
         for entry in resultArray {
-            DataManager.testing.updateAndSave(entry: entry)
+            testContainer.dataManager.updateAndSave(entry: entry)
         }
         return resultArray
     }


### PR DESCRIPTION
This PR moves DataManager class from separate singletons to protocol based polymorphism. The change reduces the intertwine between testing, preview and production environment and allows for easier implementations of preview and testing environments. Additionally production DataManager was refactored to get rid of inefficient big data pulls, and FetchRequestControllers. Instead of using published properties updated with FRCs, all DataManaging compliant classes use dataDidChange publisher<Void, Never>.

Added:
- DataManaging
- PreviewDataManager
- TestDataManager
