### PR TITLE
Fix wrong translation for override settings header in Edit sheet view

### DIFF
--- a/PunchPad/Features/History/View/EditSheetView.swift
+++ b/PunchPad/Features/History/View/EditSheetView.swift
@@ -345,7 +345,7 @@ extension EditSheetView: Localized {
         static let breaktimeText = Localization.EditSheetScreen.breaktime
         static let titleText = Localization.EditSheetScreen.editEntry
         static let timeIndicatorText = Localization.Common.worktime
-        static let overrideSettingsHeaderText = Localization.Common.overtime
+        static let overrideSettingsHeaderText = Localization.EditSheetScreen.overrideSettings.capitalized
         static let startDateText = Localization.Common.start.capitalized
         static let finishDateText = Localization.Common.finish.capitalized
         static let dateText = Localization.EditSheetScreen.date

--- a/PunchPad/Features/Localization/Localization.swift
+++ b/PunchPad/Features/Localization/Localization.swift
@@ -116,7 +116,7 @@ struct Localization {
         static let regularTime = String(localized: "Regular time")
         static let breaktime = String(localized: "Break time")
         static let editEntry = String(localized: "Edit entry")
-        static let overrideSettings = String(localized: "Override settings") 
+        static let overrideSettings = String(localized: "override settings") 
         static let date = String(localized: "Date")
         static let maximumOvertime = String(localized: "Maximum overtime")
         static let standardWorkTime = String(localized: "Standard work time")


### PR DESCRIPTION
Issue was caused by mistake in referencing localisable properties when preparing codebase for translation of displayed strings. Static property in EditSheetView.Strings overrideSettingsHeaderText was referencing wrong Localization property. Issue was fixed by changing reference to valid Localization property.