### PR TITLE
72 punchpad does not keep state when closed

### DIFF
--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		D6D02FB029EF0B7F006CD0B2 /* EditSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAF29EF0B7F006CD0B2 /* EditSheetViewModel.swift */; };
 		D6D51BC02BF65B4F00C9A0E1 /* TimerStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D51BBF2BF65B4F00C9A0E1 /* TimerStoring.swift */; };
 		D6D51BC22BF65C2F00C9A0E1 /* TimerStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D51BC12BF65C2F00C9A0E1 /* TimerStoreError.swift */; };
+		D6D51BC42BF65E6700C9A0E1 /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D51BC32BF65E6700C9A0E1 /* TimerManager.swift */; };
 		D6D906AE2AA0BEDE004E09C9 /* ScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */; };
 		D6D906B12AA12BDB004E09C9 /* BackgroundFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906B02AA12BDB004E09C9 /* BackgroundFactory.swift */; };
 		D6E2C15929D6C20E00229286 /* WorkHistory.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = D6E2C15729D6C20E00229286 /* WorkHistory.xcdatamodeld */; };
@@ -266,6 +267,7 @@
 		D6D02FAF29EF0B7F006CD0B2 /* EditSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetViewModel.swift; sourceTree = "<group>"; };
 		D6D51BBF2BF65B4F00C9A0E1 /* TimerStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStoring.swift; sourceTree = "<group>"; };
 		D6D51BC12BF65C2F00C9A0E1 /* TimerStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStoreError.swift; sourceTree = "<group>"; };
+		D6D51BC32BF65E6700C9A0E1 /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
 		D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenIdentifier.swift; sourceTree = "<group>"; };
 		D6D906B02AA12BDB004E09C9 /* BackgroundFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFactory.swift; sourceTree = "<group>"; };
 		D6E2C15829D6C20E00229286 /* WorkHistory.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = WorkHistory.xcdatamodel; sourceTree = "<group>"; };
@@ -764,6 +766,7 @@
 				D67633FE2BF5536600D45163 /* TimerStore.swift */,
 				D6D51BBF2BF65B4F00C9A0E1 /* TimerStoring.swift */,
 				D6D51BC12BF65C2F00C9A0E1 /* TimerStoreError.swift */,
+				D6D51BC32BF65E6700C9A0E1 /* TimerManager.swift */,
 			);
 			path = TimerService;
 			sourceTree = "<group>";
@@ -984,6 +987,7 @@
 				D684A38A2AF6F54B00511E0D /* ButtonFactory.swift in Sources */,
 				D63719442BCDC060006536DA /* ContainerProtocol.swift in Sources */,
 				D6C458C529D35EAA0069D89B /* SettingsView.swift in Sources */,
+				D6D51BC42BF65E6700C9A0E1 /* TimerManager.swift in Sources */,
 				D6FA94FB2B013C770034B16A /* ChartLegendItem.swift in Sources */,
 				D67633FD2BF5500500D45163 /* TimerServiceEvent.swift in Sources */,
 				D666ADCC2AC05A0500B74663 /* CaseIterable+Extension.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -55,6 +55,10 @@
 		D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */; };
 		D67332E72AADB8B1005FFE7F /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */; };
 		D67332EA2AAE3D3D005FFE7F /* StatisticsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */; };
+		D67633F92BF54E4300D45163 /* TimerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67633F82BF54E4300D45163 /* TimerModel.swift */; };
+		D67633FB2BF54F7F00D45163 /* TimerServiceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67633FA2BF54F7F00D45163 /* TimerServiceState.swift */; };
+		D67633FD2BF5500500D45163 /* TimerServiceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67633FC2BF5500500D45163 /* TimerServiceEvent.swift */; };
+		D67633FF2BF5536600D45163 /* TimerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67633FE2BF5536600D45163 /* TimerStore.swift */; };
 		D6799EFC29E1BC0F0080E32A /* HistoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */; };
 		D682AF922B3C77F5004EE208 /* ChartTimeRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = D682AF912B3C77F5004EE208 /* ChartTimeRange.swift */; };
 		D682AF942B3D83A2004EE208 /* EntrySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D682AF932B3D83A2004EE208 /* EntrySummary.swift */; };
@@ -205,6 +209,10 @@
 		D66A4DFF2B7AD46100D16110 /* Published+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Published+Extension.swift"; sourceTree = "<group>"; };
 		D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgument.swift; sourceTree = "<group>"; };
 		D67332E92AAE3D3D005FFE7F /* StatisticsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsUITests.swift; sourceTree = "<group>"; };
+		D67633F82BF54E4300D45163 /* TimerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerModel.swift; sourceTree = "<group>"; };
+		D67633FA2BF54F7F00D45163 /* TimerServiceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerServiceState.swift; sourceTree = "<group>"; };
+		D67633FC2BF5500500D45163 /* TimerServiceEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerServiceEvent.swift; sourceTree = "<group>"; };
+		D67633FE2BF5536600D45163 /* TimerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStore.swift; sourceTree = "<group>"; };
 		D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModelTests.swift; sourceTree = "<group>"; };
 		D6801A142B404F61003F54F9 /* NavigationKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NavigationKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D682AF912B3C77F5004EE208 /* ChartTimeRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartTimeRange.swift; sourceTree = "<group>"; };
@@ -746,6 +754,10 @@
 			isa = PBXGroup;
 			children = (
 				D629CEF82B3613660036579D /* TimerService.swift */,
+				D67633FC2BF5500500D45163 /* TimerServiceEvent.swift */,
+				D67633FA2BF54F7F00D45163 /* TimerServiceState.swift */,
+				D67633F82BF54E4300D45163 /* TimerModel.swift */,
+				D67633FE2BF5536600D45163 /* TimerStore.swift */,
 			);
 			path = TimerService;
 			sourceTree = "<group>";
@@ -947,10 +959,12 @@
 				D6EF97922BE7FB6900AD719C /* PreviewDataManager.swift in Sources */,
 				D6D906B12AA12BDB004E09C9 /* BackgroundFactory.swift in Sources */,
 				D6D02FB029EF0B7F006CD0B2 /* EditSheetViewModel.swift in Sources */,
+				D67633FB2BF54F7F00D45163 /* TimerServiceState.swift in Sources */,
 				D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */,
 				D6FE20872B46EE0D00F931CD /* ConfirmDeleteRowView.swift in Sources */,
 				D698F3F02B5C131D00D9DFF4 /* NotificationService.swift in Sources */,
 				D6FA94FD2B013F060034B16A /* ChartLegendItemView.swift in Sources */,
+				D67633F92BF54E4300D45163 /* TimerModel.swift in Sources */,
 				D6E2C15B29D6C31800229286 /* HistoryViewModel.swift in Sources */,
 				D6EA695C2AF8452A00D8F6C3 /* TextFactory.swift in Sources */,
 				D6CE83F82BD4443300DA0882 /* Localized.swift in Sources */,
@@ -965,6 +979,7 @@
 				D63719442BCDC060006536DA /* ContainerProtocol.swift in Sources */,
 				D6C458C529D35EAA0069D89B /* SettingsView.swift in Sources */,
 				D6FA94FB2B013C770034B16A /* ChartLegendItem.swift in Sources */,
+				D67633FD2BF5500500D45163 /* TimerServiceEvent.swift in Sources */,
 				D666ADCC2AC05A0500B74663 /* CaseIterable+Extension.swift in Sources */,
 				D6CE83F62BD443CD00DA0882 /* Localization.swift in Sources */,
 				D65FD53D29D8B259006CC34F /* PersistanceController.swift in Sources */,
@@ -994,6 +1009,7 @@
 				D6D02FAE29EF0B13006CD0B2 /* EditSheetView.swift in Sources */,
 				D6AB737029F562E600D5DE82 /* OnboardingViewModel.swift in Sources */,
 				D6C4589429D229210069D89B /* ClockInApp.swift in Sources */,
+				D67633FF2BF5536600D45163 /* TimerStore.swift in Sources */,
 				D6E2C15929D6C20E00229286 /* WorkHistory.xcdatamodeld in Sources */,
 				D60EB9B62AB0D7000053136A /* Container.swift in Sources */,
 				D6B2BDF22B27810700CB4FA7 /* DateFilterSheetView.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		D6CE83F82BD4443300DA0882 /* Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CE83F72BD4443300DA0882 /* Localized.swift */; };
 		D6D02FAE29EF0B13006CD0B2 /* EditSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */; };
 		D6D02FB029EF0B7F006CD0B2 /* EditSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAF29EF0B7F006CD0B2 /* EditSheetViewModel.swift */; };
+		D6D51BC02BF65B4F00C9A0E1 /* TimerStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D51BBF2BF65B4F00C9A0E1 /* TimerStoring.swift */; };
+		D6D51BC22BF65C2F00C9A0E1 /* TimerStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D51BC12BF65C2F00C9A0E1 /* TimerStoreError.swift */; };
 		D6D906AE2AA0BEDE004E09C9 /* ScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */; };
 		D6D906B12AA12BDB004E09C9 /* BackgroundFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906B02AA12BDB004E09C9 /* BackgroundFactory.swift */; };
 		D6E2C15929D6C20E00229286 /* WorkHistory.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = D6E2C15729D6C20E00229286 /* WorkHistory.xcdatamodeld */; };
@@ -262,6 +264,8 @@
 		D6CE83F72BD4443300DA0882 /* Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localized.swift; sourceTree = "<group>"; };
 		D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetView.swift; sourceTree = "<group>"; };
 		D6D02FAF29EF0B7F006CD0B2 /* EditSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetViewModel.swift; sourceTree = "<group>"; };
+		D6D51BBF2BF65B4F00C9A0E1 /* TimerStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStoring.swift; sourceTree = "<group>"; };
+		D6D51BC12BF65C2F00C9A0E1 /* TimerStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStoreError.swift; sourceTree = "<group>"; };
 		D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenIdentifier.swift; sourceTree = "<group>"; };
 		D6D906B02AA12BDB004E09C9 /* BackgroundFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFactory.swift; sourceTree = "<group>"; };
 		D6E2C15829D6C20E00229286 /* WorkHistory.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = WorkHistory.xcdatamodel; sourceTree = "<group>"; };
@@ -758,6 +762,8 @@
 				D67633FA2BF54F7F00D45163 /* TimerServiceState.swift */,
 				D67633F82BF54E4300D45163 /* TimerModel.swift */,
 				D67633FE2BF5536600D45163 /* TimerStore.swift */,
+				D6D51BBF2BF65B4F00C9A0E1 /* TimerStoring.swift */,
+				D6D51BC12BF65C2F00C9A0E1 /* TimerStoreError.swift */,
 			);
 			path = TimerService;
 			sourceTree = "<group>";
@@ -995,6 +1001,7 @@
 				D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */,
 				D68384F929DB25DD00228491 /* SettingViewModel.swift in Sources */,
 				D6C458C329D2DE2D0069D89B /* HomeView.swift in Sources */,
+				D6D51BC02BF65B4F00C9A0E1 /* TimerStoring.swift in Sources */,
 				D6CA773D2B40B68900C98AF3 /* MainView.swift in Sources */,
 				D621C0CC2B3B8BE40065DF8C /* TimerIndicator.swift in Sources */,
 				D6CBB86A2B34C7150074CE8B /* FormatterFactory.swift in Sources */,
@@ -1009,6 +1016,7 @@
 				D6D02FAE29EF0B13006CD0B2 /* EditSheetView.swift in Sources */,
 				D6AB737029F562E600D5DE82 /* OnboardingViewModel.swift in Sources */,
 				D6C4589429D229210069D89B /* ClockInApp.swift in Sources */,
+				D6D51BC22BF65C2F00C9A0E1 /* TimerStoreError.swift in Sources */,
 				D67633FF2BF5536600D45163 /* TimerStore.swift in Sources */,
 				D6E2C15929D6C20E00229286 /* WorkHistory.xcdatamodeld in Sources */,
 				D60EB9B62AB0D7000053136A /* Container.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		D60480D82B122CDA00D6D70D /* ChartPeriodServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60480D72B122CDA00D6D70D /* ChartPeriodServiceTests.swift */; };
 		D60480DA2B122D3F00D6D70D /* ChartPeriodService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60480D92B122D3F00D6D70D /* ChartPeriodService.swift */; };
 		D60594DC2AA7A2C400B8B264 /* SettingsViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60594DB2AA7A2C400B8B264 /* SettingsViewScreen.swift */; };
+		D606361B2BF8F9210026FC00 /* TimerManagerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */; };
 		D60D21F22AA30F310055BE34 /* HomeViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60D21F12AA30F310055BE34 /* HomeViewScreen.swift */; };
 		D60D21F32AA330BC0055BE34 /* ScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */; };
 		D60D21F52AA357BA0055BE34 /* OnboardingViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60D21F42AA357BA0055BE34 /* OnboardingViewScreen.swift */; };
@@ -169,6 +170,7 @@
 		D60480D72B122CDA00D6D70D /* ChartPeriodServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartPeriodServiceTests.swift; sourceTree = "<group>"; };
 		D60480D92B122D3F00D6D70D /* ChartPeriodService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartPeriodService.swift; sourceTree = "<group>"; };
 		D60594DB2AA7A2C400B8B264 /* SettingsViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewScreen.swift; sourceTree = "<group>"; };
+		D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerManagerConfiguration.swift; path = PunchPad/Features/TimerService/TimerManagerConfiguration.swift; sourceTree = "<group>"; };
 		D60D21F12AA30F310055BE34 /* HomeViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewScreen.swift; sourceTree = "<group>"; };
 		D60D21F42AA357BA0055BE34 /* OnboardingViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewScreen.swift; sourceTree = "<group>"; };
 		D60EB9B52AB0D7000053136A /* Container.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
@@ -395,6 +397,7 @@
 		D6C4588729D229200069D89B = {
 			isa = PBXGroup;
 			children = (
+				D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */,
 				D6C4589229D229210069D89B /* PunchPad */,
 				D6C458A329D229230069D89B /* PunchPadTests */,
 				D6C458AD29D229230069D89B /* PunchPadUITests */,
@@ -959,6 +962,7 @@
 				D63719462BCE5B5C006536DA /* PreviewContainer.swift in Sources */,
 				D682AF922B3C77F5004EE208 /* ChartTimeRange.swift in Sources */,
 				D69C8CD72B43687700146EFA /* CustomDatePickerContainer.swift in Sources */,
+				D606361B2BF8F9210026FC00 /* TimerManagerConfiguration.swift in Sources */,
 				D63753B02B45DA5000386482 /* GreenBorderTextFieldStyle.swift in Sources */,
 				D6E6B8772AF992F90073D911 /* OnboardingFinishView.swift in Sources */,
 				D6CA773F2B40BB4D00C98AF3 /* Route.swift in Sources */,

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		D60480DA2B122D3F00D6D70D /* ChartPeriodService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60480D92B122D3F00D6D70D /* ChartPeriodService.swift */; };
 		D60594DC2AA7A2C400B8B264 /* SettingsViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60594DB2AA7A2C400B8B264 /* SettingsViewScreen.swift */; };
 		D606361B2BF8F9210026FC00 /* TimerManagerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */; };
+		D606361D2BF925760026FC00 /* TimerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D606361C2BF925760026FC00 /* TimerManagerTests.swift */; };
 		D60D21F22AA30F310055BE34 /* HomeViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60D21F12AA30F310055BE34 /* HomeViewScreen.swift */; };
 		D60D21F32AA330BC0055BE34 /* ScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */; };
 		D60D21F52AA357BA0055BE34 /* OnboardingViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60D21F42AA357BA0055BE34 /* OnboardingViewScreen.swift */; };
@@ -171,6 +172,7 @@
 		D60480D92B122D3F00D6D70D /* ChartPeriodService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartPeriodService.swift; sourceTree = "<group>"; };
 		D60594DB2AA7A2C400B8B264 /* SettingsViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewScreen.swift; sourceTree = "<group>"; };
 		D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerManagerConfiguration.swift; path = PunchPad/Features/TimerService/TimerManagerConfiguration.swift; sourceTree = "<group>"; };
+		D606361C2BF925760026FC00 /* TimerManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManagerTests.swift; sourceTree = "<group>"; };
 		D60D21F12AA30F310055BE34 /* HomeViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewScreen.swift; sourceTree = "<group>"; };
 		D60D21F42AA357BA0055BE34 /* OnboardingViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewScreen.swift; sourceTree = "<group>"; };
 		D60EB9B52AB0D7000053136A /* Container.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 			isa = PBXGroup;
 			children = (
 				D61945EB29E7306B0046DE1F /* HomeViewModelTests.swift */,
+				D606361C2BF925760026FC00 /* TimerManagerTests.swift */,
 				D66A4DFB2B7AD3C900D16110 /* Extensions */,
 				D6799EFB29E1BC0F0080E32A /* HistoryViewModelTests.swift */,
 				D629CEFA2B363B500036579D /* TimerServiceTests.swift */,
@@ -1052,6 +1055,7 @@
 				D61945F029E735D80046DE1F /* MockTimer.swift in Sources */,
 				D6C458A529D229230069D89B /* ClockInTests.swift in Sources */,
 				D6CBB8662B3443360074CE8B /* EditSheetViewModelTests.swift in Sources */,
+				D606361D2BF925760026FC00 /* TimerManagerTests.swift in Sources */,
 				D6799EFC29E1BC0F0080E32A /* HistoryViewModelTests.swift in Sources */,
 				D66A4E002B7AD46100D16110 /* Published+Extension.swift in Sources */,
 			);

--- a/PunchPad.xcodeproj/project.pbxproj
+++ b/PunchPad.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		D60480D72B122CDA00D6D70D /* ChartPeriodServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartPeriodServiceTests.swift; sourceTree = "<group>"; };
 		D60480D92B122D3F00D6D70D /* ChartPeriodService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartPeriodService.swift; sourceTree = "<group>"; };
 		D60594DB2AA7A2C400B8B264 /* SettingsViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewScreen.swift; sourceTree = "<group>"; };
-		D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerManagerConfiguration.swift; path = PunchPad/Features/TimerService/TimerManagerConfiguration.swift; sourceTree = "<group>"; };
+		D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManagerConfiguration.swift; sourceTree = "<group>"; };
 		D606361C2BF925760026FC00 /* TimerManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManagerTests.swift; sourceTree = "<group>"; };
 		D60D21F12AA30F310055BE34 /* HomeViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewScreen.swift; sourceTree = "<group>"; };
 		D60D21F42AA357BA0055BE34 /* OnboardingViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewScreen.swift; sourceTree = "<group>"; };
@@ -399,7 +399,6 @@
 		D6C4588729D229200069D89B = {
 			isa = PBXGroup;
 			children = (
-				D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */,
 				D6C4589229D229210069D89B /* PunchPad */,
 				D6C458A329D229230069D89B /* PunchPadTests */,
 				D6C458AD29D229230069D89B /* PunchPadUITests */,
@@ -765,6 +764,7 @@
 		D6FD09502BCC49C100AD8989 /* TimerService */ = {
 			isa = PBXGroup;
 			children = (
+				D606361A2BF8F9210026FC00 /* TimerManagerConfiguration.swift */,
 				D629CEF82B3613660036579D /* TimerService.swift */,
 				D67633FC2BF5500500D45163 /* TimerServiceEvent.swift */,
 				D67633FA2BF54F7F00D45163 /* TimerServiceState.swift */,

--- a/PunchPad/Features/Home/View/HomeView.swift
+++ b/PunchPad/Features/Home/View/HomeView.swift
@@ -71,7 +71,7 @@ extension HomeView: Localized {
 //MARK: - Timer Controls
 private extension HomeView {
     @ViewBuilder
-    func makeControls(_ state: TimerService.TimerServiceState) -> some View {
+    func makeControls(_ state: TimerServiceState) -> some View {
         switch state {
         case .running:
             HStack {

--- a/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
+++ b/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
@@ -15,6 +15,7 @@ class HomeViewModel: NSObject, ObservableObject {
     private var settingsStore: SettingsStore
     private var payManager: PayManager
     private var notificationService: NotificationService
+    private var timerManagerConfiguration: TimerManagerConfiguration
     private var timerManager: TimerManager
     private var timerStore: TimerStore = .init(defaults: .standard)
     private var timerProvider: Timer.Type
@@ -52,13 +53,13 @@ class HomeViewModel: NSObject, ObservableObject {
         self.timerProvider = timerProvider
         self.payManager = payManager
         self.notificationService = notificationService
-        let configuration = TimerManagerConfiguration(
+        self.timerManagerConfiguration = TimerManagerConfiguration(
             workTimeInSeconds: TimeInterval(settingsStore.workTimeInSeconds),
             isLoggingOvertime: settingsStore.isLoggingOvertime,
             overtimeInSeconds: TimeInterval(settingsStore.maximumOvertimeAllowedInSeconds)
         )
         self.timerManager = TimerManager(timerProvider: timerProvider,
-                                    with: configuration)
+                                         with: timerManagerConfiguration)
         super.init()
         
         setUpStoreSubscribers()

--- a/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
+++ b/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
@@ -20,7 +20,7 @@ class HomeViewModel: NSObject, ObservableObject {
     private var timerProvider: Timer.Type = Timer.self
     private var workTimerService: TimerService
     private var overtimeTimerService: TimerService?
-    @Published var state: TimerService.TimerServiceState = .notStarted
+    @Published var state: TimerServiceState = .notStarted
     var timerDisplayValue: TimeInterval {
         if let overtimeTimerService = overtimeTimerService {
             if overtimeTimerService.progress > 0 {

--- a/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
+++ b/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
@@ -175,6 +175,11 @@ extension HomeViewModel {
             .sink { [weak self] _ in
                 self?.appWillEnterForeground()
             }.store(in: &subscriptions)
+        NotificationCenter.default
+            .publisher(for: UIApplication.willTerminateNotification)
+            .sink { _ in
+                print("App will terminate - should save timer configuration present in background")
+            }.store(in: &subscriptions)
     }
     
     /// Set appDidEnterBackgroundDate to now and set notifications for worktime and overtime timers finish

--- a/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
+++ b/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
@@ -53,6 +53,8 @@ class HomeViewModel: NSObject, ObservableObject {
         self.timerProvider = timerProvider
         self.payManager = payManager
         self.notificationService = notificationService
+        #warning("#3 - cover with unit test and make sure implementation works")
+        // TODO: ALWAYS INIT FROM MODEL, IF NOT PRESENT, INIT WITHOUT MODEL, GET MODEL FROM STORE ON INIT
         self.timerManagerConfiguration = TimerManagerConfiguration(
             workTimeInSeconds: TimeInterval(settingsStore.workTimeInSeconds),
             isLoggingOvertime: settingsStore.isLoggingOvertime,

--- a/PunchPad/Features/TimerService/TimerManager.swift
+++ b/PunchPad/Features/TimerService/TimerManager.swift
@@ -6,3 +6,146 @@
 //
 
 import Foundation
+import Combine
+
+class TimerManager: ObservableObject {
+    private let timerProvider: Timer.Type
+    private let configuration: TimerManagerConfiguration
+    private var timerCancellables = Set<AnyCancellable>()
+    var workTimerService: TimerService
+    var overtimeTimerService: TimerService?
+    @Published var state: TimerServiceState = .notStarted
+    var timerDidFinish: PassthroughSubject<Date, Never> = .init()
+    
+    
+    init(timerProvider: Timer.Type = Timer.self, with configuration: TimerManagerConfiguration) {
+        self.timerProvider = timerProvider
+        self.configuration = configuration
+        self.workTimerService = .init(timerProvider: timerProvider, 
+                                      timerLimit: configuration.workTimeInSeconds)
+        if configuration.isLoggingOvertime,
+            let limit = configuration.overtimeInSeconds {
+            self.overtimeTimerService = .init(timerProvider: timerProvider, 
+                                              timerLimit: limit)
+        }
+        setUpSubscriptions()
+    }
+
+    private func setUpSubscriptions() {
+        // clear timer cancellables from old references
+        timerCancellables = .init()
+        
+        workTimerService.objectWillChange.sink { _ in
+            self.objectWillChange.send()
+        }.store(in: &timerCancellables)
+    
+        overtimeTimerService?.objectWillChange.sink(receiveValue: { _ in
+            self.objectWillChange.send()
+        }).store(in: &timerCancellables)
+        
+        if let overtimeTimerService = self.overtimeTimerService {
+            
+            self.workTimerService.$serviceState.filter { state in
+                state == .finished
+            }.sink { [weak self] _ in
+                self?.overtimeTimerService?.send(event: .start)
+            }.store(in: &timerCancellables)
+            
+            overtimeTimerService.$serviceState.filter { state in
+                state == .finished
+            }.sink { [weak self] _ in
+                guard let self else { return }
+                self.state = .finished
+                self.timerDidFinish.send(Date())
+            }.store(in: &timerCancellables)
+            
+        } else {
+            self.workTimerService.$serviceState.filter { state in
+                return state == .finished
+            }.sink { [weak self] _ in
+                guard let self else { return }
+                self.state = .finished
+                self.timerDidFinish.send(Date())
+            }.store(in: &timerCancellables)
+        }
+    }
+    
+    func startTimerService() {
+        guard state != .running else { return }
+        if state == .finished {
+            workTimerService = .init(
+                timerProvider: timerProvider,
+                timerLimit: configuration.workTimeInSeconds
+            )
+            if configuration.isLoggingOvertime, let limit = configuration.overtimeInSeconds {
+                overtimeTimerService = .init(
+                    timerProvider: timerProvider,
+                    timerLimit: limit
+                )
+            }
+            setUpSubscriptions()
+        }
+        self.state = .running
+        workTimerService.send(event: .start)
+    }
+    
+    func pauseTimerService() {
+        guard state != .paused else { return }
+        self.state = .paused
+        workTimerService.send(event: .pause)
+        overtimeTimerService?.send(event: .pause)
+    }
+    
+    func resumeTimerService() {
+        guard state != .running else { return }
+        self.state = .running
+        workTimerService.send(event: .resumeWith(nil))
+        overtimeTimerService?.send(event: .resumeWith(nil))
+    }
+    
+    func stopTimerService() {
+        guard state != .finished else { return }
+        workTimerService.send(event: .stop)
+        overtimeTimerService?.send(event: .stop)
+    }
+    
+    func resumeFromBackground(_ appDidEnterBackgroundDate: Date) {
+        let timePassedInBackground = DateInterval(start: appDidEnterBackgroundDate, end: Date()).duration
+        
+        guard let overtimeTimerService else {
+            if workTimerService.serviceState == .running {
+                if timePassedInBackground < workTimerService.remainingTime {
+                    workTimerService.send(event: .resumeWith(timePassedInBackground))
+                } else {
+                    self.timerDidFinish.send(appDidEnterBackgroundDate.addingTimeInterval(workTimerService.remainingTime))
+                    workTimerService.send(event: .resumeWith(timePassedInBackground))
+                }
+            }
+            return
+        }
+        if workTimerService.serviceState == .running {
+            if workTimerService.remainingTime < timePassedInBackground {
+                let worktimePassedInBackground = workTimerService.remainingTime
+                let overtimePassedInBackground = timePassedInBackground - worktimePassedInBackground
+                workTimerService.send(event: .resumeWith(worktimePassedInBackground))
+                overtimeTimerService.send(event: .start)
+                if overtimePassedInBackground < overtimeTimerService.remainingTime {
+                    overtimeTimerService.send(event: .resumeWith(overtimePassedInBackground))
+                } else {
+                    self.timerDidFinish.send( appDidEnterBackgroundDate.addingTimeInterval(worktimePassedInBackground + overtimeTimerService.remainingTime))
+                    overtimeTimerService.send(event: .resumeWith(overtimeTimerService.remainingTime))
+                }
+            } else {
+                workTimerService.send(event: .resumeWith(timePassedInBackground))
+            }
+        } else if overtimeTimerService.serviceState == .running {
+            if overtimeTimerService.remainingTime < timePassedInBackground {
+                let remainingOvertime = overtimeTimerService.remainingTime
+                self.timerDidFinish.send(appDidEnterBackgroundDate.addingTimeInterval(remainingOvertime))
+                overtimeTimerService.send(event: .resumeWith(remainingOvertime))
+            } else {
+                overtimeTimerService.send(event: .resumeWith(timePassedInBackground))
+            }
+        }
+    }
+}

--- a/PunchPad/Features/TimerService/TimerManager.swift
+++ b/PunchPad/Features/TimerService/TimerManager.swift
@@ -29,6 +29,14 @@ class TimerManager: ObservableObject {
         }
         setUpSubscriptions()
     }
+    #warning("#2 - MAKE SURE IT WORK WITH UNIT TESTS")
+    convenience init(timerProvider: Timer.Type = Timer.self, withModel model: TimerModel) {
+        self.init(timerProvider: timerProvider, with: model.configuration)
+        setInitialState(ofTimerService: workTimerService, toCounter: model.workTimeCounter, toState: model.workTimerState)
+        if let overtimeTimerService, let counter = model.overtimeCounter, let state = model.overtimeTimerState {
+            setInitialState(ofTimerService: overtimeTimerService, toCounter: counter, toState: state)
+        }
+    }
 
     private func setUpSubscriptions() {
         // clear timer cancellables from old references

--- a/PunchPad/Features/TimerService/TimerManager.swift
+++ b/PunchPad/Features/TimerService/TimerManager.swift
@@ -1,0 +1,8 @@
+//
+//  TimerManager.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 16/05/2024.
+//
+
+import Foundation

--- a/PunchPad/Features/TimerService/TimerManagerConfiguration.swift
+++ b/PunchPad/Features/TimerService/TimerManagerConfiguration.swift
@@ -1,0 +1,14 @@
+//
+//  TimerManagerConfiguration.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 18/05/2024.
+//
+
+import Foundation
+
+struct TimerManagerConfiguration: Codable {
+    let workTimeInSeconds: TimeInterval
+    let isLoggingOvertime: Bool
+    let overtimeInSeconds: TimeInterval?
+}

--- a/PunchPad/Features/TimerService/TimerModel.swift
+++ b/PunchPad/Features/TimerService/TimerModel.swift
@@ -14,4 +14,13 @@ struct TimerModel: Codable {
     let workTimerState: TimerServiceState
     let overtimeTimerState: TimerServiceState?
     let timeStamp: Date
+    
+    static func initial(configuration: TimerManagerConfiguration) -> TimerModel {
+        return TimerModel(configuration: configuration,
+                          workTimeCounter: 0,
+                          overtimeCounter: 0,
+                          workTimerState: .notStarted,
+                          overtimeTimerState: configuration.isLoggingOvertime ? .notStarted : nil,
+                          timeStamp: .now)
+    }
 }

--- a/PunchPad/Features/TimerService/TimerModel.swift
+++ b/PunchPad/Features/TimerService/TimerModel.swift
@@ -1,0 +1,8 @@
+//
+//  TimerModel.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 15/05/2024.
+//
+
+import Foundation

--- a/PunchPad/Features/TimerService/TimerModel.swift
+++ b/PunchPad/Features/TimerService/TimerModel.swift
@@ -6,3 +6,13 @@
 //
 
 import Foundation
+
+struct TimerModel: Codable {
+    let workTime: TimeInterval
+    let overtime: TimeInterval?
+    let workTimeCounter: TimeInterval
+    let overtimeCounter: TimeInterval?
+    let workTimerState: TimerServiceState
+    let overtimeTimerState: TimerServiceState
+    let timeStamp: Date
+}

--- a/PunchPad/Features/TimerService/TimerModel.swift
+++ b/PunchPad/Features/TimerService/TimerModel.swift
@@ -8,11 +8,10 @@
 import Foundation
 
 struct TimerModel: Codable {
-    let workTime: TimeInterval
-    let overtime: TimeInterval?
+    let configuration: TimerManagerConfiguration
     let workTimeCounter: TimeInterval
     let overtimeCounter: TimeInterval?
     let workTimerState: TimerServiceState
-    let overtimeTimerState: TimerServiceState
+    let overtimeTimerState: TimerServiceState?
     let timeStamp: Date
 }

--- a/PunchPad/Features/TimerService/TimerService.swift
+++ b/PunchPad/Features/TimerService/TimerService.swift
@@ -9,13 +9,6 @@ import Foundation
 import SwiftUI
 
 class TimerService: ObservableObject {
-    enum TimerServiceState {
-        case running, paused, notStarted, finished
-    }
-    enum TimerServiceEvent {
-        case start, stop, pause, resumeWith(TimeInterval?)
-    }
-    
     private let timerProvider: Timer.Type
     private var timer: Timer?
     private let timerLimit: TimeInterval

--- a/PunchPad/Features/TimerService/TimerService.swift
+++ b/PunchPad/Features/TimerService/TimerService.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-class TimerService: ObservableObject {
+final class TimerService: ObservableObject {
     private let timerProvider: Timer.Type
     private var timer: Timer?
     private let timerLimit: TimeInterval
@@ -78,5 +78,33 @@ class TimerService: ObservableObject {
     
     private func updateProgressCounter() {
         progress = CGFloat(counter / timerLimit)
+    }
+    #warning("#1 - MAKE SURE IT WORK WITH UNIT TESTS")
+    fileprivate func setTimerService(counter value: TimeInterval) {
+        guard value <= timerLimit else {
+            preconditionFailure("Attempted to set value larger than timer limit, this should not happen")
+        }
+        counter = value
+        updateProgressCounter()
+    }
+    fileprivate func setTimerService(state: TimerServiceState) {
+        serviceState = state
+    }
+    
+    fileprivate func attachTimer() {
+        timer = timerProvider.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
+            guard let self else { return }
+            self.updateTimer()
+        })
+    }
+}
+
+extension TimerManager {
+    func setInitialState(ofTimerService service: TimerService, toCounter value: TimeInterval, toState state: TimerServiceState) {
+        service.setTimerService(counter: value)
+        service.setTimerService(state: state)
+        if state == .running || state == .paused {
+            service.attachTimer()
+        }
     }
 }

--- a/PunchPad/Features/TimerService/TimerServiceEvent.swift
+++ b/PunchPad/Features/TimerService/TimerServiceEvent.swift
@@ -1,0 +1,11 @@
+//
+//  TimerServiceEvent.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 15/05/2024.
+//
+
+import Foundation
+enum TimerServiceEvent {
+    case start, stop, pause, resumeWith(TimeInterval?)
+}

--- a/PunchPad/Features/TimerService/TimerServiceState.swift
+++ b/PunchPad/Features/TimerService/TimerServiceState.swift
@@ -1,0 +1,12 @@
+//
+//  TimerServiceState.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 15/05/2024.
+//
+
+import Foundation
+
+enum TimerServiceState: Codable {
+    case running, paused, notStarted, finished
+}

--- a/PunchPad/Features/TimerService/TimerStore.swift
+++ b/PunchPad/Features/TimerService/TimerStore.swift
@@ -7,11 +7,7 @@
 
 import Foundation
 
-enum TimerStoreError: Error {
-    case failedToRetrieveData
-}
-
-struct TimerStore {
+struct TimerStore: TimerStoring {
     let storageKey = "timerModel"
     let defaults: UserDefaults
     
@@ -22,7 +18,6 @@ struct TimerStore {
     func retrieve() throws -> TimerModel {
         let decoder = JSONDecoder()
         let data = defaults.data(forKey: storageKey)
-        defaults.removeObject(forKey: storageKey)
         if let data {
             let model = try decoder.decode(TimerModel.self, from: data)
             return model
@@ -35,5 +30,9 @@ struct TimerStore {
         let encoder = JSONEncoder()
         let data = try encoder.encode(timerModel)
         defaults.set(data, forKey: storageKey)
+    }
+    
+    func delete() {
+        defaults.removeObject(forKey: storageKey)
     }
 }

--- a/PunchPad/Features/TimerService/TimerStore.swift
+++ b/PunchPad/Features/TimerService/TimerStore.swift
@@ -6,9 +6,11 @@
 //
 
 import Foundation
+
 enum TimerStoreError: Error {
     case failedToRetrieveData
 }
+
 struct TimerStore {
     let storageKey = "timerModel"
     let defaults: UserDefaults

--- a/PunchPad/Features/TimerService/TimerStore.swift
+++ b/PunchPad/Features/TimerService/TimerStore.swift
@@ -1,0 +1,37 @@
+//
+//  TimerStore.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 15/05/2024.
+//
+
+import Foundation
+enum TimerStoreError: Error {
+    case failedToRetrieveData
+}
+struct TimerStore {
+    let storageKey = "timerModel"
+    let defaults: UserDefaults
+    
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+    
+    func retrieve() throws -> TimerModel {
+        let decoder = JSONDecoder()
+        let data = defaults.data(forKey: storageKey)
+        defaults.removeObject(forKey: storageKey)
+        if let data {
+            let model = try decoder.decode(TimerModel.self, from: data)
+            return model
+        } else {
+            throw TimerStoreError.failedToRetrieveData
+        }
+    }
+    
+    func save(_ timerModel: TimerModel) throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(timerModel)
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/PunchPad/Features/TimerService/TimerStoreError.swift
+++ b/PunchPad/Features/TimerService/TimerStoreError.swift
@@ -1,0 +1,12 @@
+//
+//  TimerStoreError.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 16/05/2024.
+//
+
+import Foundation
+
+enum TimerStoreError: Error {
+    case failedToRetrieveData
+}

--- a/PunchPad/Features/TimerService/TimerStoring.swift
+++ b/PunchPad/Features/TimerService/TimerStoring.swift
@@ -1,0 +1,14 @@
+//
+//  TimerStoring.swift
+//  PunchPad
+//
+//  Created by Tomasz Kubiak on 16/05/2024.
+//
+
+import Foundation
+
+protocol TimerStoring {
+    func retrieve() throws -> TimerModel
+    func save(_: TimerModel) throws
+    func delete()
+}

--- a/PunchPad/Localizable.xcstrings
+++ b/PunchPad/Localizable.xcstrings
@@ -154,7 +154,7 @@
     "Ooops! Something went wrong,\nor you never recorded time..." : {
 
     },
-    "Override settings" : {
+    "override settings" : {
 
     },
     "overtime" : {

--- a/PunchPadTests.xctestplan
+++ b/PunchPadTests.xctestplan
@@ -14,9 +14,21 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "ChartPeriodServiceTests",
+        "ClockInTests",
+        "EditSheetViewModelTests",
+        "HistoryViewModelTests",
+        "HomeViewModelModelTests\/test_resumeFromBackground_whenEnteredDuringSecondTimer_withTwoTimers_exceedingSecondTimer()",
         "HomeViewModelModelTests\/test_resumeFromBackground_withOneTimer_exceedingTimerLimit()",
         "HomeViewModelModelTests\/test_resumeFromBackground_withOneTimer_exceedingTimerLimit_savesEntry()",
-        "HomeViewModelModelTests\/test_resumeFromBackground_withOneTimer_notExceedingTimerLimit()"
+        "HomeViewModelModelTests\/test_resumeFromBackground_withOneTimer_notExceedingTimerLimit()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_withTwoTimers_exceedingFirstTimerLimit()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_withTwoTimers_exceedingSecondTimer()",
+        "HomeViewModelModelTests\/test_resumeFromBackground_withTwoTimers_notExceedingFirstTimerLimit()",
+        "PayManagerTests",
+        "StatisticsViewModelTests",
+        "TimerManagerTests",
+        "TimerServiceTests"
       ],
       "target" : {
         "containerPath" : "container:PunchPad.xcodeproj",

--- a/PunchPadTests/HomeViewModelTests.swift
+++ b/PunchPadTests/HomeViewModelTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import PunchPad
 
-final class HomeViewModelModelTests: XCTestCase {
+final class HomeViewModelTests: XCTestCase {
     var sut: HomeViewModel!
     var testContainer: TestContainer!
 
@@ -37,7 +37,7 @@ final class HomeViewModelModelTests: XCTestCase {
 }
 
 //MARK: TIMER STATE CHANGE FUNCTIONS
-extension HomeViewModelModelTests {
+extension HomeViewModelTests {
     func test_startTimerService_when_noOvertime_firstRun() {
         //Given
         let expectedState: TimerServiceState = .running
@@ -111,43 +111,6 @@ extension HomeViewModelModelTests {
         XCTAssertEqual(sut.timerDisplayValue, TimeInterval(2 * numberOfFires), "Timer display value should be equal to \(2 * numberOfFires)")
         XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
         XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
-    }
-    
-    func test_resumeFromBackground_when_timerServiceWasStarted_noOvertime() {
-        //Given
-        let numberOfSecondsPassedInBackground = 10
-        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
-        let expectedNormalProgressValue = CGFloat(numberOfSecondsPassedInBackground) / CGFloat(workTimerLimit)
-        let expectedOvertimeProgressValue = CGFloat(0)
-        var enterBackgroundDate: Date {
-            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
-        }
-        setUpWithOneTimer()
-        //When
-        sut.startTimerService()
-        sut.resumeFromBackground(enterBackgroundDate)
-        //Then
-        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(expectedDisplayValue)")
-        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, accuracy: 0.01, "Normal progress should be equal to \(expectedNormalProgressValue)")
-        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
-    }
-    
-    func test_resumeFromBackground_when_timerServiceWasNotStarted_noOvertime() {
-        //Given
-        let numberOfSecondsPassedInBackground = 10
-        let expectedDisplayValue = TimeInterval(0)
-        let expectedNormalProgressValue = CGFloat(0)
-        let expectedOvertimeProgressValue = CGFloat(0)
-        var enterBackgroundDate: Date {
-            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
-        }
-        setUpWithOneTimer()
-        //When
-        sut.resumeFromBackground(enterBackgroundDate)
-        //Then
-        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(numberOfSecondsPassedInBackground)")
-        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, accuracy: 0.01, "Normal progress should be equal to \(expectedNormalProgressValue)")
-        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
     }
     
     func test_stopTimerService_stopsServiceAndSavesEntry_noOvertime() throws {
@@ -276,66 +239,6 @@ extension HomeViewModelModelTests {
         XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
     }
     
-    func test_resumeFromBackground_whenSecondTimerWasStarted() {
-        //Given
-        let numberOfSecondsPassedInBackground = 11
-        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
-        let expectedNormalProgressValue = CGFloat(1)
-        let expectedOvertimeProgressValue = CGFloat(numberOfSecondsPassedInBackground) / CGFloat(overtimeTimerLimit)
-        var enterBackgroundDate: Date {
-            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
-        }
-        setUpWithTwoTimers()
-        //When
-        sut.startTimerService()
-        fireTimer(workTimerLimit)
-        sut.resumeFromBackground(enterBackgroundDate)
-        //Then
-        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(expectedDisplayValue)")
-        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
-        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
-    }
-    
-    func test_resumeFromBackground_whenTimeInBackgroundExceedsFirstTimeLimit() {
-        //Given
-        let numberOfSecondsPassedInBackground = workTimerLimit + 10
-        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground - workTimerLimit)
-        let expectedNormalProgressValue = CGFloat(1)
-        let expectedOvertimeProgressValue = CGFloat(numberOfSecondsPassedInBackground - workTimerLimit) / CGFloat(overtimeTimerLimit)
-        var enterBackgroundDate: Date {
-            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
-        }
-        setUpWithTwoTimers()
-        //When
-        sut.startTimerService()
-        
-        sut.resumeFromBackground(enterBackgroundDate)
-        //Then
-        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(expectedDisplayValue)")
-        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
-        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
-    }
-    
-    func test_resumeFromBackground_whenTimeInBackgroundExceedsSumOfTimeLimits() {
-        //Given
-        let numberOfSecondsPassedInBackground = workTimerLimit + overtimeTimerLimit
-        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground - workTimerLimit)
-        let expectedNormalProgressValue = CGFloat(1)
-        let expectedOvertimeProgressValue = CGFloat(1)
-        var enterBackgroundDate: Date {
-            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground - 20, to: Date())!
-        }
-        setUpWithTwoTimers()
-        //When
-        sut.startTimerService()
-        
-        sut.resumeFromBackground(enterBackgroundDate)
-        //Then
-        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(expectedDisplayValue)")
-        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
-        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
-    }
-    
     func test_stopTimerService_stopsSecondTimerAndSavesEntry() throws {
         let numberOfFires = workTimerLimit + overtimeTimerLimit
         let expectedDisplayValue = TimeInterval(overtimeTimerLimit)
@@ -369,7 +272,7 @@ extension HomeViewModelModelTests {
 }
 
 //MARK: BACKGROUND AND FOREGROUND TIMER UPDATES
-extension HomeViewModelModelTests {
+extension HomeViewModelTests {
     func test_resumeFromBackground_withOneTimer_notExceedingTimerLimit() {
         //Given
         setUpWithOneTimer()
@@ -483,8 +386,9 @@ extension HomeViewModelModelTests {
         let expectedEntriesCount = try numberOfEntries() + 1
         sut.startTimerService()
         fireTimer(3)
+        sleep(3)
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        sleep(5)
+        sleep(2)
         //When
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
         //Then
@@ -503,7 +407,7 @@ extension HomeViewModelModelTests {
 }
 
 //MARK: HELPERS
-extension HomeViewModelModelTests {
+extension HomeViewModelTests {
     private func setUpWithOneTimer() {
         testContainer.settingsStore.isLoggingOvertime = false
         testContainer.settingsStore.workTimeInSeconds = workTimerLimit

--- a/PunchPadTests/HomeViewModelTests.swift
+++ b/PunchPadTests/HomeViewModelTests.swift
@@ -40,7 +40,7 @@ final class HomeViewModelModelTests: XCTestCase {
 extension HomeViewModelModelTests {
     func test_startTimerService_when_noOvertime_firstRun() {
         //Given
-        let expectedState: TimerService.TimerServiceState = .running
+        let expectedState: TimerServiceState = .running
         setUpWithOneTimer()
         //When
         sut.startTimerService()
@@ -50,7 +50,7 @@ extension HomeViewModelModelTests {
     
     func test_startTimerService_when_noOvertime_secondRun() {
         //Given
-        let expectedState: TimerService.TimerServiceState = .running
+        let expectedState: TimerServiceState = .running
         let expectedProgress = CGFloat(0.2)
         let expectedDisplayValue = TimeInterval(integerLiteral: 20)
         setUpWithOneTimer()
@@ -192,7 +192,7 @@ extension HomeViewModelModelTests {
     }
     func test_startSecondTimer_whenFirstIsFinished_secondRun() {
         //Given
-        let expectedState: TimerService.TimerServiceState = .running
+        let expectedState: TimerServiceState = .running
         let expectedProgress = CGFloat(0.2)
         let expectedDisplayValue = TimeInterval(integerLiteral: 20)
         setUpWithTwoTimers()

--- a/PunchPadTests/TimerManagerTests.swift
+++ b/PunchPadTests/TimerManagerTests.swift
@@ -1,0 +1,35 @@
+//
+//  TimerManagerTests.swift
+//  PunchPadTests
+//
+//  Created by Tomasz Kubiak on 18/05/2024.
+//
+
+import XCTest
+
+final class TimerManagerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/PunchPadTests/TimerManagerTests.swift
+++ b/PunchPadTests/TimerManagerTests.swift
@@ -6,30 +6,467 @@
 //
 
 import XCTest
+@testable import PunchPad
 
 final class TimerManagerTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    var sut: TimerManager!
+    var workTimerLimit: Int = 100
+    var overtimeTimerLimit: Int = 100
+    
+    override func setUp() {
+        super.setUp()
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
     }
+}
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+//MARK: TIMER STATE CHANGE FUNCTIONS
+extension TimerManagerTests {
+    func test_startTimerService_when_noOvertime_firstRun() {
+        //Given
+        let expectedState: TimerServiceState = .running
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        //Then
+        XCTAssertEqual(sut.state, expectedState, "State should be equal to \(expectedState)")
     }
+    
+    func test_startTimerService_when_noOvertime_secondRun() {
+        //Given
+        let expectedState: TimerServiceState = .running
+        let expectedProgress = CGFloat(0.2)
+        let expectedDisplayValue = TimeInterval(integerLiteral: 20)
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        fireTimer(10)
+        sut.stopTimerService()
+        sut.startTimerService()
+        fireTimer(20)
+        //Then
+        XCTAssertEqual(sut.state, expectedState, "State should be equal to \(expectedState)")
+        XCTAssertEqual(sut.workTimerService.progress, expectedProgress)
+        XCTAssertEqual(sut.workTimerService.counter, expectedDisplayValue)
+    }
+    
+    func test_timerProperties_updateWhenRunning_noOvertime() {
+        //Given
+        let numberOfFires = 10
+        let expectedNormalProgressValue = CGFloat(numberOfFires) / CGFloat(workTimerLimit)
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        fireTimer(10)
+        //Then
+        XCTAssertEqual(sut.workTimerService.counter,
+                       TimeInterval(numberOfFires),
+                       "Timer display value should be equal to 10")
+        XCTAssertEqual(sut.workTimerService.progress, 
+                       expectedNormalProgressValue,
+                       "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertNil(sut.overtimeTimerService,
+                     "Overtime service should be nil")
+    }
+    
+    func test_timerProperties_notUpdating_whenPaused_noOvertime() {
+        //Given
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        fireTimer(10)
+        sut.pauseTimerService()
+        fireTimer(10)
+        //Then
+        XCTAssertEqual(sut.workTimerService.counter,
+                       TimeInterval(integerLiteral: 10),
+                       "Timer display value should be equal to 10")
+        XCTAssertEqual(sut.workTimerService.progress,
+                       CGFloat(0.1),
+                       "Normal progress should be equal to 0.1")
+        XCTAssertNil(sut.overtimeTimerService,
+                     "Overtime timer service should be nil")
+    }
+    
+    func test_resumeTimerService_whenPaused_noOvertime() {
+        //Given
+        let numberOfFires = 10
+        let expectedNormalProgressValue = CGFloat(2 * numberOfFires) / CGFloat(workTimerLimit)
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        fireTimer(10)
+        sut.pauseTimerService()
+        sut.resumeTimerService()
+        fireTimer(10)
+        //Then
+        XCTAssertEqual(sut.workTimerService.counter, 
+                       TimeInterval(2 * numberOfFires),
+                       "Timer display value should be equal to \(2 * numberOfFires)")
+        XCTAssertEqual(sut.workTimerService.progress, 
+                       expectedNormalProgressValue,
+                       "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertNil(sut.overtimeTimerService,
+                     "Overtime  timer service should be nil")
+    }
+    
+    func test_resumeFromBackground_when_timerServiceWasStarted_noOvertime() {
+        //Given
+        let numberOfSecondsPassedInBackground = 10
+        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
+        let expectedNormalProgressValue = CGFloat(numberOfSecondsPassedInBackground) / CGFloat(workTimerLimit)
+        var enterBackgroundDate: Date {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
+        }
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        XCTAssertEqual(sut.workTimerService.counter,
+                       expectedDisplayValue,
+                       accuracy: 0.01,
+                       "Counter value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.workTimerService.progress,
+                       expectedNormalProgressValue,
+                       accuracy: 0.01,
+                       "Work timer progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertNil(sut.overtimeTimerService,
+                       "Overtime timer service should be nil")
+    }
+    
+    func test_resumeFromBackground_when_timerServiceWasNotStarted_noOvertime() {
+        //Given
+        let numberOfSecondsPassedInBackground = 10
+        let expectedDisplayValue = TimeInterval(0)
+        let expectedNormalProgressValue = CGFloat(0)
+        var enterBackgroundDate: Date {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
+        }
+        setUpWithOneTimer()
+        //When
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        XCTAssertEqual(sut.workTimerService.counter,
+                       expectedDisplayValue,
+                       accuracy: 0.01,
+                       "work timer counter value should be equal to \(numberOfSecondsPassedInBackground)")
+        XCTAssertEqual(sut.workTimerService.progress,
+                       expectedNormalProgressValue,
+                       accuracy: 0.01,
+                       "Work timer service progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertNil(sut.overtimeTimerService,
+                       "Overtime progress should be nil")
+    }
+    
+    func test_stopTimerService_stopsServiceAndEmitsDate_noOvertime() throws {
+        //Given
+        let numberOfFires = 10
+        let expectation = XCTestExpectation(description: "Date emitted")
+        setUpWithOneTimer()
+        let datePublisher = sut.timerDidFinish
+            .sink { _ in
+                expectation.fulfill()
+            }
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        sut.stopTimerService()
+        //Then
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(sut.state, .finished, "Service state should be finished")
+    }
+    
+    func test_timerFinished_stopsServiceAndEmitsDate_noOvertime() throws {
+        //Given
+        let numberOfFires = workTimerLimit + 1
+        let expectation = XCTestExpectation(description: "Date emitted")
+        setUpWithOneTimer()
+        let datePublisher = sut.timerDidFinish
+            .sink { _ in
+                expectation.fulfill()
+            }
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        //Then
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(sut.state, .finished, "Service state should be finished")
+    }
+     
+    
+    func test_startSecondTimer_whenFirstIsFinished_firstRun() {
+        //Given
+        let numberOfFires = workTimerLimit + 1
+        let expectedNormalProgress = CGFloat(1)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        //Then
+        XCTAssertEqual(sut.workTimerService.progress,
+                       expectedNormalProgress,
+                       "Normal progress should be equal to 0")
+        XCTAssert(sut.overtimeTimerService?.progress ?? 0 > 0,
+                  "Overtime progress should be bigger than 0")
+        XCTAssertEqual(sut.state, .running, "SUT state should be running")
+    }
+    
+    func test_startSecondTimer_whenFirstIsFinished_secondRun() {
+        //Given
+        let expectedState: TimerServiceState = .running
+        let expectedProgress = CGFloat(0.2)
+        let expectedDisplayValue = TimeInterval(integerLiteral: 20)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(workTimerLimit + 10)
+        sut.stopTimerService()
+        sut.startTimerService()
+        fireTimer(workTimerLimit + 20)
+        //Then
+        XCTAssertEqual(sut.state, expectedState, "State should be equal to \(expectedState)")
+        XCTAssertEqual(sut.overtimeTimerService?.progress ?? 0, expectedProgress)
+        XCTAssertEqual(sut.overtimeTimerService?.counter ?? 0, expectedDisplayValue)
+    }
+    
+    func test_displayedValue_whenFirstTimerFinished_whenSecondTimerStarts() {
+        //Given
+        let expectedDisplayValueFromFirstTimer: CGFloat = 100
+        let expectedDisplayValueFromSecondTimer: CGFloat = 1
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(workTimerLimit)
+        //Then
+        XCTAssertEqual(sut.workTimerService.counter, expectedDisplayValueFromFirstTimer)
+        //When
+        fireTimer(1)
+        //Then
+        XCTAssertEqual(sut.overtimeTimerService?.counter ?? 0, expectedDisplayValueFromSecondTimer)
+    }
+    
+    func test_timerPropertiesUpdate_whenSecondTimerIsRunning() throws {
+        //Given
+        let numberOfFires = workTimerLimit + 10
+        let expectedDisplayValue = TimeInterval(10)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(numberOfFires - workTimerLimit) / CGFloat(overtimeTimerLimit)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        //Then
+        let overtimeService = try XCTUnwrap(sut.overtimeTimerService)
+        XCTAssertEqual(overtimeService.counter, expectedDisplayValue, "Timer display value should be equal to 10")
+        XCTAssertEqual(sut.workTimerService.progress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(overtimeService.progress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_timerProperties_notUpdating_whenPaused_withOvertime() throws {
+        //Given
+        let numberOfFires = workTimerLimit + 10
+        let expectedDisplayValue = TimeInterval(10)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(numberOfFires - workTimerLimit) / CGFloat(overtimeTimerLimit)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        sut.pauseTimerService()
+        fireTimer(10)
+        //Then
+        let overtimeService = try XCTUnwrap(sut.overtimeTimerService)
+        XCTAssertEqual(overtimeService.counter, expectedDisplayValue, "Timer display value should be equal to 10")
+        XCTAssertEqual(sut.workTimerService.progress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(overtimeService.progress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_resumeTimerService_whenPaused_withOvertime() throws {
+        //Given
+        let numberOfFires = workTimerLimit + 10
+        let expectedDisplayValue = TimeInterval(20)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(20) / CGFloat(overtimeTimerLimit)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        sut.pauseTimerService()
+        sut.resumeTimerService()
+        fireTimer(10)
+        //Then
+        let overtimeService = try XCTUnwrap(sut.overtimeTimerService)
+        XCTAssertEqual(overtimeService.counter,
+                       expectedDisplayValue ,
+                       "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.workTimerService.progress,
+                       expectedNormalProgressValue,
+                       "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(overtimeService.progress,
+                       expectedOvertimeProgressValue,
+                       "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_resumeFromBackground_whenSecondTimerWasStarted() throws {
+        //Given
+        let numberOfSecondsPassedInBackground = 11
+        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(numberOfSecondsPassedInBackground) / CGFloat(overtimeTimerLimit)
+        var enterBackgroundDate: Date {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
+        }
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(workTimerLimit)
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        let overtimeService = try XCTUnwrap(sut.overtimeTimerService)
+        XCTAssertEqual(overtimeService.counter,
+                       expectedDisplayValue,
+                       accuracy: 0.01,
+                       "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.workTimerService.progress,
+                       expectedNormalProgressValue,
+                       "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(overtimeService.progress,
+                       expectedOvertimeProgressValue,
+                       accuracy: 0.01,
+                       "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_resumeFromBackground_whenTimeInBackgroundExceedsFirstTimeLimit() throws {
+        //Given
+        let numberOfSecondsPassedInBackground = workTimerLimit + 10
+        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground - workTimerLimit)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(numberOfSecondsPassedInBackground - workTimerLimit) / CGFloat(overtimeTimerLimit)
+        var enterBackgroundDate: Date {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
+        }
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        let overtimeService = try XCTUnwrap(sut.overtimeTimerService)
+        XCTAssertEqual(overtimeService.counter,
+                       expectedDisplayValue,
+                       accuracy: 0.01,
+                       "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.workTimerService.progress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(overtimeService.progress,
+                       expectedOvertimeProgressValue,
+                       accuracy: 0.01,
+                       "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_resumeFromBackground_whenTimeInBackgroundExceedsSumOfTimeLimits() throws {
+        //Given
+        let numberOfSecondsPassedInBackground = workTimerLimit + overtimeTimerLimit
+        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground - workTimerLimit)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(1)
+        var enterBackgroundDate: Date {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground - 20, to: Date())!
+        }
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        let overtimeService = try XCTUnwrap(sut.overtimeTimerService)
+        XCTAssertEqual(overtimeService.counter, 
+                       expectedDisplayValue, 
+                       accuracy: 0.01,
+                       "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.workTimerService.progress,
+                       expectedNormalProgressValue,
+                       "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(overtimeService.progress,
+                       expectedOvertimeProgressValue, 
+                       accuracy: 0.01,
+                       "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_stopTimerService_stopsSecondTimerAndSavesEntry() throws {
+        let numberOfFires = workTimerLimit + overtimeTimerLimit
+        let expectedDisplayValue = TimeInterval(overtimeTimerLimit)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(1)
+        let expectation = XCTestExpectation(description: "Date emitted")
+        setUpWithTwoTimers()
+        let datePublisher = sut.timerDidFinish.sink { date in
+            print("DatePublisher: \(date)")
+            expectation.fulfill()
+        }
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        sut.stopTimerService()
+        //Then
+        wait(for: [expectation], timeout: 0.5)
+        let overtimeService = try XCTUnwrap(sut.overtimeTimerService)
+        XCTAssertEqual(overtimeService.counter,
+                       expectedDisplayValue,
+                       accuracy: 0.01,
+                       "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.workTimerService.progress,
+                       expectedNormalProgressValue,
+                       "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(overtimeService.progress,
+                       expectedOvertimeProgressValue,
+                       accuracy: 0.01,
+                       "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_secondTimerFinished_stopsServiceAndSavesEntry() throws {
+        //Given
+        let expectation = XCTestExpectation(description: "Date emitted")
+        let numberOfFires = workTimerLimit + overtimeTimerLimit + 1
+        setUpWithTwoTimers()
+        let datePublisher = sut.timerDidFinish.sink { _ in
+            expectation.fulfill()
+        }
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        //Then
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(sut.state, .finished, "Service state should be finished")
+    }
+}
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+//MARK: HELPERS
+extension TimerManagerTests {
+    private func setUpWithOneTimer() {
+        let configuration = TimerManagerConfiguration(workTimeInSeconds: TimeInterval(workTimerLimit),
+                                                              isLoggingOvertime: false,
+                                                              overtimeInSeconds: nil)
+        sut = .init(timerProvider: MockTimer.self,
+                    with: configuration)
+        
+    }
+    
+    private func setUpWithTwoTimers() {
+        let configuration = TimerManagerConfiguration(workTimeInSeconds: TimeInterval(workTimerLimit),
+                                                              isLoggingOvertime: true,
+                                                              overtimeInSeconds: TimeInterval(overtimeTimerLimit))
+        sut = TimerManager(timerProvider: MockTimer.self,
+                           with: configuration)
+    }
+    
+    private func fireTimer(_ numberOfFires: Int) {
+        for _ in 0...numberOfFires - 1 {
+            MockTimer.currentTimer.fire()
         }
     }
-
 }
+


### PR DESCRIPTION
This PR solves issue where app would not keep state of the timer between launches. 

To solve the issue several entities were added: 
- TimerModel (holds timer configuration and current timers state) 
- Timer Store (responsible for saving, retrieving and deleting tiemer models) 
- TimerManager - responsible for managing separate timers 

In this PR the view model initialises timer manager with retrieved timer model, or with timer configuration constructed based on current settings. If a timer model is retrieved and set, the state of the timers is as on last exit from the app, addressing the issue of loosing tracked time between the launches. 