### PR TITLE
I-72: Punch pad does not keep state when closed

### DIFF
--- a/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
+++ b/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
@@ -17,7 +17,7 @@ class HomeViewModel: NSObject, ObservableObject {
     private var notificationService: NotificationService
     private var timerManagerConfiguration: TimerManagerConfiguration
     private var timerManager: TimerManager
-    private var timerStore: TimerStore = .init(defaults: .standard)
+    private var timerStore: TimerStoring
     private var timerProvider: Timer.Type
     private var timersNotRunning: Bool { 
         self.state == .notStarted || self.state == .finished
@@ -51,12 +51,14 @@ class HomeViewModel: NSObject, ObservableObject {
          settingsStore: SettingsStore,
          payManager: PayManager,
          notificationService: NotificationService,
-         timerProvider: Timer.Type = Timer.self) {
+         timerProvider: Timer.Type = Timer.self,
+         timerStore: TimerStoring = TimerStore(defaults: .standard)) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
         self.timerProvider = timerProvider
         self.payManager = payManager
         self.notificationService = notificationService
+        self.timerStore = timerStore
         #warning("#3 - cover with unit test and make sure implementation works")
         do {
             self.currentTimerModel = try self.timerStore.retrieve()

--- a/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
+++ b/PunchPad/Features/Home/ViewModel/HomeViewModel.swift
@@ -59,7 +59,7 @@ class HomeViewModel: NSObject, ObservableObject {
         self.payManager = payManager
         self.notificationService = notificationService
         self.timerStore = timerStore
-        #warning("#3 - cover with unit test and make sure implementation works")
+        
         do {
             self.currentTimerModel = try self.timerStore.retrieve()
             self.timerManagerConfiguration = currentTimerModel!.configuration


### PR DESCRIPTION
**Why it is needed:**
This PR builds on PR #74 and adds testing to recovering timer. 

**What was done:**
- small refactor to enable testing 
- add timer store mock 
- add init tests with new mock